### PR TITLE
Refactor/moving vehicle out of pb unique

### DIFF
--- a/awc-content/src/main/java/com/mersiades/awccontent/enums/UniqueType.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/enums/UniqueType.java
@@ -5,7 +5,6 @@ public enum UniqueType {
     CUSTOM_WEAPONS,
     BRAINER_GEAR,
     GANG,
-    VEHICLE,
     WEAPONS,
     HOLDING,
     FOLLOWERS,

--- a/awc-content/src/main/java/com/mersiades/awccontent/enums/VehicleType.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/enums/VehicleType.java
@@ -1,0 +1,7 @@
+package com.mersiades.awccontent.enums;
+
+public enum VehicleType {
+    BIKE,
+    CAR,
+    COMBAT
+}

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/BikeCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/BikeCreator.java
@@ -1,7 +1,6 @@
-package com.mersiades.awccontent.models.uniquecreators;
+package com.mersiades.awccontent.models;
 
-import com.mersiades.awccontent.models.VehicleBattleOption;
-import com.mersiades.awccontent.models.VehicleFrame;
+import com.mersiades.awccontent.enums.VehicleType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,14 +14,16 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CarCreator {
+public class BikeCreator {
 
     @Id
     private String id;
 
+    private VehicleType vehicleType;
+
     private String introInstructions;
 
-    private List<VehicleFrame> frames;
+    private VehicleFrame frame;
 
     @Builder.Default
     private List<String> strengths = new ArrayList<>();

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/CarCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/CarCreator.java
@@ -1,7 +1,6 @@
-package com.mersiades.awcdata.models.uniques;
+package com.mersiades.awccontent.models;
 
-import com.mersiades.awccontent.models.VehicleBattleOption;
-import com.mersiades.awccontent.models.VehicleFrame;
+import com.mersiades.awccontent.enums.VehicleType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,35 +14,26 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Vehicle {
+public class CarCreator {
 
     @Id
     private String id;
 
-    private String name;
+    private VehicleType vehicleType;
 
-    private VehicleFrame vehicleFrame;
+    private String introInstructions;
 
-    private int speed;
-
-    private int handling;
-
-    private int armor;
-
-    private int massive;
+    private List<VehicleFrame> frames;
 
     @Builder.Default
     private List<String> strengths = new ArrayList<>();
 
     @Builder.Default
-    private List<String> weaknesses = new ArrayList<>();
-
-    @Builder.Default
     private List<String> looks = new ArrayList<>();
 
     @Builder.Default
+    private List<String> weaknesses = new ArrayList<>();
+
+    @Builder.Default
     private List<VehicleBattleOption> battleOptions = new ArrayList<>();
-
-
-
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/CombatVehicleCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/CombatVehicleCreator.java
@@ -1,7 +1,6 @@
-package com.mersiades.awccontent.models.uniquecreators;
+package com.mersiades.awccontent.models;
 
-import com.mersiades.awccontent.models.VehicleBattleOption;
-import com.mersiades.awccontent.models.VehicleFrame;
+import com.mersiades.awccontent.enums.VehicleType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,14 +14,16 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class BikeCreator {
+public class CombatVehicleCreator {
 
     @Id
     private String id;
 
+    private VehicleType vehicleType;
+
     private String introInstructions;
 
-    private VehicleFrame frame;
+    private List<VehicleFrame> frames;
 
     @Builder.Default
     private List<String> strengths = new ArrayList<>();

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/PlaybookCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/PlaybookCreator.java
@@ -31,6 +31,8 @@ public class PlaybookCreator {
 
     private PlaybookUniqueCreator playbookUniqueCreator;
 
+    private int defaultVehicleCount;
+
     @Builder.Default
     private List<Move> optionalMoves = new ArrayList<>();
 

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/PlaybookUniqueCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/PlaybookUniqueCreator.java
@@ -24,9 +24,4 @@ public class PlaybookUniqueCreator {
     private CustomWeaponsCreator customWeaponsCreator;
 
     private BrainerGearCreator brainerGearCreator;
-
-    private CarCreator carCreator;
-
-    private BikeCreator bikeCreator;
-
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/VehicleCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/VehicleCreator.java
@@ -1,0 +1,22 @@
+package com.mersiades.awccontent.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VehicleCreator {
+    @Id
+    private String id;
+
+    private CarCreator carCreator;
+
+    private BikeCreator bikeCreator;
+
+    private CombatVehicleCreator combatVehicleCreator;
+}

--- a/awc-content/src/main/java/com/mersiades/awccontent/repositories/VehicleCreatorRepository.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/repositories/VehicleCreatorRepository.java
@@ -1,0 +1,7 @@
+package com.mersiades.awccontent.repositories;
+
+import com.mersiades.awccontent.models.VehicleCreator;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface VehicleCreatorRepository extends ReactiveMongoRepository<VehicleCreator, String> {
+}

--- a/awc-content/src/main/java/com/mersiades/awccontent/services/VehicleCreatorService.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/services/VehicleCreatorService.java
@@ -1,0 +1,6 @@
+package com.mersiades.awccontent.services;
+
+import com.mersiades.awccontent.models.VehicleCreator;
+
+public interface VehicleCreatorService extends ReactiveCrudService<VehicleCreator, String> {
+}

--- a/awc-content/src/main/java/com/mersiades/awccontent/services/impl/VehicleCreatorServiceImpl.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/services/impl/VehicleCreatorServiceImpl.java
@@ -1,0 +1,48 @@
+package com.mersiades.awccontent.services.impl;
+
+import com.mersiades.awccontent.models.VehicleCreator;
+import com.mersiades.awccontent.repositories.VehicleCreatorRepository;
+import com.mersiades.awccontent.services.VehicleCreatorService;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class VehicleCreatorServiceImpl implements VehicleCreatorService {
+
+    private final VehicleCreatorRepository vehicleCreatorRepository;
+
+    public VehicleCreatorServiceImpl(VehicleCreatorRepository vehicleCreatorRepository) {
+        this.vehicleCreatorRepository = vehicleCreatorRepository;
+    }
+
+    @Override
+    public Flux<VehicleCreator> findAll() {
+        return vehicleCreatorRepository.findAll();
+    }
+
+    @Override
+    public Mono<VehicleCreator> findById(String id) {
+        return vehicleCreatorRepository.findById(id);
+    }
+
+    @Override
+    public Mono<VehicleCreator> save(VehicleCreator vehicleCreator) {
+        return vehicleCreatorRepository.save(vehicleCreator);
+    }
+
+    @Override
+    public Flux<VehicleCreator> saveAll(Flux<VehicleCreator> vehicleCreatorFlux) {
+        return vehicleCreatorRepository.saveAll(vehicleCreatorFlux);
+    }
+
+    @Override
+    public void delete(VehicleCreator vehicleCreator) {
+        vehicleCreatorRepository.delete(vehicleCreator);
+    }
+
+    @Override
+    public void deleteById(String id) {
+        vehicleCreatorRepository.deleteById(id);
+    }
+}

--- a/awc-data/src/main/java/com/mersiades/awcdata/models/Character.java
+++ b/awc-data/src/main/java/com/mersiades/awcdata/models/Character.java
@@ -43,6 +43,9 @@ public class Character {
     private int vehicleCount;
 
     @Builder.Default
+    private List<Vehicle> vehicles = new ArrayList<>();
+
+    @Builder.Default
     private List<HxStat> hxBlock = new ArrayList<>();
 
     @Builder.Default

--- a/awc-data/src/main/java/com/mersiades/awcdata/models/PlaybookUnique.java
+++ b/awc-data/src/main/java/com/mersiades/awcdata/models/PlaybookUnique.java
@@ -4,7 +4,6 @@ import com.mersiades.awccontent.enums.UniqueType;
 import com.mersiades.awcdata.models.uniques.AngelKit;
 import com.mersiades.awcdata.models.uniques.BrainerGear;
 import com.mersiades.awcdata.models.uniques.CustomWeapons;
-import com.mersiades.awcdata.models.uniques.Vehicle;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/awc-data/src/main/java/com/mersiades/awcdata/models/Vehicle.java
+++ b/awc-data/src/main/java/com/mersiades/awcdata/models/Vehicle.java
@@ -1,0 +1,52 @@
+package com.mersiades.awcdata.models;
+
+import com.mersiades.awccontent.enums.VehicleType;
+import com.mersiades.awccontent.models.VehicleBattleOption;
+import com.mersiades.awccontent.models.VehicleFrame;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Vehicle {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private VehicleType vehicleType;
+
+    private VehicleFrame vehicleFrame;
+
+    private int speed;
+
+    private int handling;
+
+    private int armor;
+
+    private int massive;
+
+    @Builder.Default
+    private List<String> strengths = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> weaknesses = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> looks = new ArrayList<>();
+
+    @Builder.Default
+    private List<VehicleBattleOption> battleOptions = new ArrayList<>();
+
+
+
+}

--- a/awc-data/src/main/java/com/mersiades/awcdata/services/GameRoleService.java
+++ b/awc-data/src/main/java/com/mersiades/awcdata/services/GameRoleService.java
@@ -5,7 +5,7 @@ import com.mersiades.awcdata.models.*;
 import com.mersiades.awccontent.enums.LookType;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.enums.StatType;
-import com.mersiades.awcdata.models.uniques.Vehicle;
+import com.mersiades.awcdata.models.Vehicle;
 import reactor.core.publisher.Flux;
 
 import java.util.List;

--- a/awc-data/src/main/java/com/mersiades/awcdata/services/impl/GameRoleServiceImpl.java
+++ b/awc-data/src/main/java/com/mersiades/awcdata/services/impl/GameRoleServiceImpl.java
@@ -375,38 +375,28 @@ public class GameRoleServiceImpl implements GameRoleService {
                 .filter(character1 -> character1.getId().equals(characterId)).findFirst().orElseThrow();
 
 
-        // If the Character doesn't have a PlaybookUnique yet, create one and add vehicle to it
-//        if (character.getPlaybookUnique() == null) {
-//            PlaybookUnique unique = PlaybookUnique.builder()
-//                    .id(UUID.randomUUID().toString())
-//                    .type(UniqueType.VEHICLE)
-//                    .vehicles(List.of(vehicle))
-//                    .build();
-//            character.setPlaybookUnique(unique);
-//        } else {
-//            List<Vehicle> existingVehicles = character.getPlaybookUnique().getVehicles();
-//
-//            if (existingVehicles.size() == 0) {
-//                // Add first Vehicle
-//                character.getPlaybookUnique().getVehicles().add(vehicle);
-//            } else {
-//                // Replace Vehicle with updated data, if it already exists
-//                ListIterator<Vehicle> iterator = existingVehicles.listIterator();
-//                boolean hasReplaced = false;
-//                while (iterator.hasNext()) {
-//                    Vehicle nextVehicle = iterator.next();
-//                    if (nextVehicle.getId().equals(vehicle.getId())) {
-//                        iterator.set(vehicle);
-//                        hasReplaced = true;
-//                    }
-//                }
-//
-//                if (!hasReplaced) {
-//                    // Add a new Vehicle to the existing Vehicles List
-//                    character.getPlaybookUnique().getVehicles().add(vehicle);
-//                }
-//            }
-//        }
+
+            if (character.getVehicles().size() == 0) {
+                // Add first Vehicle
+                character.getVehicles().add(vehicle);
+            } else {
+                // Replace Vehicle with updated data, if it already exists
+                ListIterator<Vehicle> iterator = character.getVehicles().listIterator();
+                boolean hasReplaced = false;
+                while (iterator.hasNext()) {
+                    Vehicle nextVehicle = iterator.next();
+                    if (nextVehicle.getId().equals(vehicle.getId())) {
+                        iterator.set(vehicle);
+                        hasReplaced = true;
+                    }
+                }
+
+                if (!hasReplaced) {
+                    // Add a new Vehicle to the existing Vehicles List
+                    character.getPlaybookUnique().getVehicles().add(vehicle);
+                }
+            }
+
 
         // Save to db
         characterService.save(character).block();

--- a/awc-data/src/main/java/com/mersiades/awcdata/services/impl/GameRoleServiceImpl.java
+++ b/awc-data/src/main/java/com/mersiades/awcdata/services/impl/GameRoleServiceImpl.java
@@ -11,7 +11,7 @@ import com.mersiades.awcdata.models.*;
 import com.mersiades.awcdata.models.uniques.AngelKit;
 import com.mersiades.awcdata.models.uniques.BrainerGear;
 import com.mersiades.awcdata.models.uniques.CustomWeapons;
-import com.mersiades.awcdata.models.uniques.Vehicle;
+import com.mersiades.awcdata.models.Vehicle;
 import com.mersiades.awcdata.repositories.GameRoleRepository;
 import com.mersiades.awcdata.services.CharacterService;
 import com.mersiades.awcdata.services.GameRoleService;
@@ -376,37 +376,37 @@ public class GameRoleServiceImpl implements GameRoleService {
 
 
         // If the Character doesn't have a PlaybookUnique yet, create one and add vehicle to it
-        if (character.getPlaybookUnique() == null) {
-            PlaybookUnique unique = PlaybookUnique.builder()
-                    .id(UUID.randomUUID().toString())
-                    .type(UniqueType.VEHICLE)
-                    .vehicles(List.of(vehicle))
-                    .build();
-            character.setPlaybookUnique(unique);
-        } else {
-            List<Vehicle> existingVehicles = character.getPlaybookUnique().getVehicles();
-
-            if (existingVehicles.size() == 0) {
-                // Add first Vehicle
-                character.getPlaybookUnique().getVehicles().add(vehicle);
-            } else {
-                // Replace Vehicle with updated data, if it already exists
-                ListIterator<Vehicle> iterator = existingVehicles.listIterator();
-                boolean hasReplaced = false;
-                while (iterator.hasNext()) {
-                    Vehicle nextVehicle = iterator.next();
-                    if (nextVehicle.getId().equals(vehicle.getId())) {
-                        iterator.set(vehicle);
-                        hasReplaced = true;
-                    }
-                }
-
-                if (!hasReplaced) {
-                    // Add a new Vehicle to the existing Vehicles List
-                    character.getPlaybookUnique().getVehicles().add(vehicle);
-                }
-            }
-        }
+//        if (character.getPlaybookUnique() == null) {
+//            PlaybookUnique unique = PlaybookUnique.builder()
+//                    .id(UUID.randomUUID().toString())
+//                    .type(UniqueType.VEHICLE)
+//                    .vehicles(List.of(vehicle))
+//                    .build();
+//            character.setPlaybookUnique(unique);
+//        } else {
+//            List<Vehicle> existingVehicles = character.getPlaybookUnique().getVehicles();
+//
+//            if (existingVehicles.size() == 0) {
+//                // Add first Vehicle
+//                character.getPlaybookUnique().getVehicles().add(vehicle);
+//            } else {
+//                // Replace Vehicle with updated data, if it already exists
+//                ListIterator<Vehicle> iterator = existingVehicles.listIterator();
+//                boolean hasReplaced = false;
+//                while (iterator.hasNext()) {
+//                    Vehicle nextVehicle = iterator.next();
+//                    if (nextVehicle.getId().equals(vehicle.getId())) {
+//                        iterator.set(vehicle);
+//                        hasReplaced = true;
+//                    }
+//                }
+//
+//                if (!hasReplaced) {
+//                    // Add a new Vehicle to the existing Vehicles List
+//                    character.getPlaybookUnique().getVehicles().add(vehicle);
+//                }
+//            }
+//        }
 
         // Save to db
         characterService.save(character).block();

--- a/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
@@ -29,6 +29,7 @@ public class GameDataLoader implements CommandLineRunner {
     private final StatsOptionService statsOptionService;
     private final MoveService moveService;
     private final StatModifierService statModifierService;
+    private final VehicleCreatorService vehicleCreatorService;
 
     @Autowired
     LookRepository lookRepository;
@@ -48,13 +49,17 @@ public class GameDataLoader implements CommandLineRunner {
     @Autowired
     StatsOptionRepository statsOptionRepository;
 
+    @Autowired
+    VehicleCreatorRepository vehicleCreatorRepository;
+
+
     public GameDataLoader(PlaybookCreatorService playbookCreatorService,
                           PlaybookService playbookService,
                           NameService nameService,
                           LookService lookService,
                           StatsOptionService statsOptionService,
                           MoveService moveService,
-                          StatModifierService statModifierService) {
+                          StatModifierService statModifierService, VehicleCreatorService vehicleCreatorService) {
         this.playbookCreatorService = playbookCreatorService;
         this.playbookService = playbookService;
         this.nameService = nameService;
@@ -62,6 +67,7 @@ public class GameDataLoader implements CommandLineRunner {
         this.statsOptionService = statsOptionService;
         this.moveService = moveService;
         this.statModifierService = statModifierService;
+        this.vehicleCreatorService = vehicleCreatorService;
     }
 
     @Override
@@ -104,6 +110,11 @@ public class GameDataLoader implements CommandLineRunner {
             loadPlaybooks();
         }
 
+        VehicleCreator vehicleCreator = vehicleCreatorRepository.findAll().take(1).blockFirst();
+        if (vehicleCreator == null) {
+            loadVehicleCreator();
+        }
+
         // 'Create if empty' conditionality is embedded in the createPlaybooks() method
         createPlaybooks();
 
@@ -111,6 +122,7 @@ public class GameDataLoader implements CommandLineRunner {
         System.out.println("Move count: " + Objects.requireNonNull(moveRepository.count().block()).toString());
         System.out.println("Name count: " + Objects.requireNonNull(nameRepository.count().block()).toString());
         System.out.println("PlaybookCreator count: " + Objects.requireNonNull(playbookCreatorRepository.count().block()).toString());
+        System.out.println("CarCreator count: " + Objects.requireNonNull(vehicleCreatorRepository.count().block()).toString());
         System.out.println("Playbook count: " + Objects.requireNonNull(playbookRepository.count().block()).toString());
     }
 
@@ -1869,6 +1881,7 @@ public class GameDataLoader implements CommandLineRunner {
                 .defaultMoves(angelDefaultMoves)
                 .defaultMoveCount(1)
                 .moveChoiceCount(2)
+                .defaultVehicleCount(0)
                 .build();
 
 
@@ -1968,6 +1981,7 @@ public class GameDataLoader implements CommandLineRunner {
                 .defaultMoves(battlebabeDefaultMoves)
                 .defaultMoveCount(1)
                 .moveChoiceCount(2)
+                .defaultVehicleCount(0)
                 .build();
 
         /* ----------------------------- BRAINER PLAYBOOK CREATOR --------------------------------- */
@@ -2038,151 +2052,20 @@ public class GameDataLoader implements CommandLineRunner {
                 .defaultMoves(brainerDefaultMoves)
                 .defaultMoveCount(1)
                 .moveChoiceCount(2)
+                .defaultVehicleCount(0)
                 .build();
 
         /* ----------------------------- CHOPPER PLAYBOOK CREATOR --------------------------------- */
-        VehicleFrame bikeFrame = VehicleFrame.builder()
-                .id(UUID.randomUUID().toString())
-                .frameType(VehicleFrameType.BIKE)
-                .massive(0)
-                .examples("Road bike, trail bike, low-rider")
-                .battleOptionCount(1)
-                .build();
-
-        VehicleBattleOption battleOption1 = VehicleBattleOption.builder()
-                .id(UUID.randomUUID().toString())
-                .battleOptionType(BattleOptionType.SPEED)
-                .name("+1speed")
-                .build();
-
-        VehicleBattleOption battleOption2 = VehicleBattleOption.builder()
-                .id(UUID.randomUUID().toString())
-                .battleOptionType(BattleOptionType.HANDLING)
-                .name("+1handling")
-                .build();
-
-        BikeCreator bikeCreator = BikeCreator.builder()
-                .id(UUID.randomUUID().toString())
-                .introInstructions("By default, your bike has speed=0, handling=0, 0-armor and the massive rating of its frame.")
-                .frame(bikeFrame)
-                .strengths(List.of("fast",
-                        "rugged",
-                        "aggressive",
-                        "tight",
-                        "huge",
-                        "responsive"))
-                .looks(List.of(
-                        "sleek",
-                        "vintage",
-                        "massively-chopped",
-                        "muscular",
-                        "flashy",
-                        "luxe",
-                        "roaring",
-                        "fat-ass"))
-                .weaknesses(List.of("slow",
-                        "sloppy",
-                        "guzzler",
-                        "lazy",
-                        "unreliable",
-                        "cramped",
-                        "loud",
-                        "picky",
-                        "rabbity"))
-                .battleOptions(List.of(battleOption1, battleOption2))
-                .build();
 
         PlaybookUniqueCreator chopperUniqueCreator = PlaybookUniqueCreator.builder()
-                .type(UniqueType.VEHICLE)
+                .type(UniqueType.GANG)
                 .id(UUID.randomUUID().toString())
-                .bikeCreator(bikeCreator)
-                // TODO: add gang creator, and probably change UniqueType to GANG
+                // TODO: add gang creator,
                 .build();
 
         /* ----------------------------- DRIVER PLAYBOOK CREATOR --------------------------------- */
 
-        VehicleFrame smallFrame = VehicleFrame.builder()
-                .id(UUID.randomUUID().toString())
-                .frameType(VehicleFrameType.SMALL)
-                .massive(1)
-                .examples("Compact, buggy")
-                .battleOptionCount(2)
-                .build();
-
-        VehicleFrame mediumFrame = VehicleFrame.builder()
-                .id(UUID.randomUUID().toString())
-                .frameType(VehicleFrameType.MEDIUM)
-                .massive(2)
-                .examples("Coupe, sedan, jeep, pickup, van, limo, 4x4, tractor")
-                .battleOptionCount(2)
-                .build();
-
-        VehicleFrame largeFrame = VehicleFrame.builder()
-                .id(UUID.randomUUID().toString())
-                .frameType(VehicleFrameType.LARGE)
-                .massive(3)
-                .examples("Semi, bus, ambulance, construction/utility")
-                .battleOptionCount(2)
-                .build();
-
-        VehicleBattleOption battleOption3 = VehicleBattleOption.builder()
-                .id(UUID.randomUUID().toString())
-                .battleOptionType(BattleOptionType.MASSIVE)
-                .name("+1massive")
-                .build();
-
-        VehicleBattleOption battleOption4 = VehicleBattleOption.builder()
-                .id(UUID.randomUUID().toString())
-                .battleOptionType(BattleOptionType.ARMOR)
-                .name("+1armor")
-                .build();
-
-        CarCreator carCreator = CarCreator.builder()
-                .id(UUID.randomUUID().toString())
-                .introInstructions("By default, your vehicle has speed=0, handling=0, 0-armor and the massive rating of its frame.")
-                .frames(List.of(bikeFrame, smallFrame, mediumFrame, largeFrame))
-                .strengths(List.of("fast",
-                        "rugged",
-                        "aggressive",
-                        "tight",
-                        "huge",
-                        "responsive",
-                        "off-road",
-                        "uncomplaining",
-                        "capacious",
-                        "workhorse",
-                        "easily repaired"))
-                .looks(List.of(
-                        "sleek",
-                        "vintage",
-                        "muscular",
-                        "flashy",
-                        "luxe",
-                        "pristine",
-                        "powerful",
-                        "quirky",
-                        "pretty",
-                        "handcrafted",
-                        "spikes & plates",
-                        "garish"))
-                .weaknesses(List.of("slow",
-                        "sloppy",
-                        "guzzler",
-                        "lazy",
-                        "unreliable",
-                        "cramped",
-                        "loud",
-                        "picky",
-                        "rabbity"))
-                .battleOptions(List.of(battleOption1, battleOption2, battleOption3, battleOption4))
-                .build();
-
-        PlaybookUniqueCreator driverUniqueCreator = PlaybookUniqueCreator.builder()
-                .type(UniqueType.VEHICLE)
-                .id(UUID.randomUUID().toString())
-                .carCreator(carCreator)
-                .bikeCreator(bikeCreator)
-                .build();
+        // Driver has no PlaybookUnique; hav Vehicles instead
 
         List<Move> driverOptionalMoves = moveRepository
                 .findAllByPlaybookAndKind(PlaybookType.DRIVER, MoveType.CHARACTER)
@@ -2232,17 +2115,156 @@ public class GameDataLoader implements CommandLineRunner {
                         "On the others’ turns, answer their questions as you like.\n" +
                         "\n" +
                         "At the end, choose one of the characters with the highest Hx on your sheet. Ask that player which of your stats is most interesting, and highlight it. The MC will have you highlight a second stat too.")
-                .playbookUniqueCreator(driverUniqueCreator)
                 .optionalMoves(driverOptionalMoves)
                 .defaultMoves(driverDefaultMoves)
                 .defaultMoveCount(1)
                 .moveChoiceCount(2)
+                .defaultVehicleCount(1)
                 .build();
 
         playbookCreatorService.saveAll(Flux.just(angelCreator,
                 battlebabePlaybookCreator,
                 playbookCreatorBrainer,
                 playbookCreatorDriver)).blockLast();
+    }
+
+    public void loadVehicleCreator() {
+        VehicleFrame bikeFrame = VehicleFrame.builder()
+                .id(UUID.randomUUID().toString())
+                .frameType(VehicleFrameType.BIKE)
+                .massive(0)
+                .examples("Road bike, trail bike, low-rider")
+                .battleOptionCount(1)
+                .build();
+
+        VehicleFrame smallFrame = VehicleFrame.builder()
+                .id(UUID.randomUUID().toString())
+                .frameType(VehicleFrameType.SMALL)
+                .massive(1)
+                .examples("Compact, buggy")
+                .battleOptionCount(2)
+                .build();
+
+        VehicleFrame mediumFrame = VehicleFrame.builder()
+                .id(UUID.randomUUID().toString())
+                .frameType(VehicleFrameType.MEDIUM)
+                .massive(2)
+                .examples("Coupe, sedan, jeep, pickup, van, limo, 4x4, tractor")
+                .battleOptionCount(2)
+                .build();
+
+        VehicleFrame largeFrame = VehicleFrame.builder()
+                .id(UUID.randomUUID().toString())
+                .frameType(VehicleFrameType.LARGE)
+                .massive(3)
+                .examples("Semi, bus, ambulance, construction/utility")
+                .battleOptionCount(2)
+                .build();
+
+        VehicleBattleOption battleOption1 = VehicleBattleOption.builder()
+                .id(UUID.randomUUID().toString())
+                .battleOptionType(BattleOptionType.SPEED)
+                .name("+1speed")
+                .build();
+
+        VehicleBattleOption battleOption2 = VehicleBattleOption.builder()
+                .id(UUID.randomUUID().toString())
+                .battleOptionType(BattleOptionType.HANDLING)
+                .name("+1handling")
+                .build();
+
+        VehicleBattleOption battleOption3 = VehicleBattleOption.builder()
+                .id(UUID.randomUUID().toString())
+                .battleOptionType(BattleOptionType.MASSIVE)
+                .name("+1massive")
+                .build();
+
+        VehicleBattleOption battleOption4 = VehicleBattleOption.builder()
+                .id(UUID.randomUUID().toString())
+                .battleOptionType(BattleOptionType.ARMOR)
+                .name("+1armor")
+                .build();
+
+        BikeCreator bikeCreator = BikeCreator.builder()
+                .id(UUID.randomUUID().toString())
+                .vehicleType(VehicleType.BIKE)
+                .introInstructions("By default, your bike has speed=0, handling=0, 0-armor and the massive rating of its frame.")
+                .frame(bikeFrame)
+                .strengths(List.of("fast",
+                        "rugged",
+                        "aggressive",
+                        "tight",
+                        "huge",
+                        "responsive"))
+                .looks(List.of(
+                        "sleek",
+                        "vintage",
+                        "massively-chopped",
+                        "muscular",
+                        "flashy",
+                        "luxe",
+                        "roaring",
+                        "fat-ass"))
+                .weaknesses(List.of("slow",
+                        "sloppy",
+                        "guzzler",
+                        "lazy",
+                        "unreliable",
+                        "cramped",
+                        "loud",
+                        "picky",
+                        "rabbity"))
+                .battleOptions(List.of(battleOption1, battleOption2))
+                .build();
+
+        CarCreator carCreator = CarCreator.builder()
+                .id(UUID.randomUUID().toString())
+                .vehicleType(VehicleType.CAR)
+                .introInstructions("By default, your vehicle has speed=0, handling=0, 0-armor and the massive rating of its frame.")
+                .frames(List.of(bikeFrame, smallFrame, mediumFrame, largeFrame))
+                .strengths(List.of("fast",
+                        "rugged",
+                        "aggressive",
+                        "tight",
+                        "huge",
+                        "responsive",
+                        "off-road",
+                        "uncomplaining",
+                        "capacious",
+                        "workhorse",
+                        "easily repaired"))
+                .looks(List.of(
+                        "sleek",
+                        "vintage",
+                        "muscular",
+                        "flashy",
+                        "luxe",
+                        "pristine",
+                        "powerful",
+                        "quirky",
+                        "pretty",
+                        "handcrafted",
+                        "spikes & plates",
+                        "garish"))
+                .weaknesses(List.of("slow",
+                        "sloppy",
+                        "guzzler",
+                        "lazy",
+                        "unreliable",
+                        "cramped",
+                        "loud",
+                        "picky",
+                        "rabbity"))
+                .battleOptions(List.of(battleOption1, battleOption2, battleOption3, battleOption4))
+                .build();
+
+        VehicleCreator vehicleCreator = VehicleCreator.builder()
+                .carCreator(carCreator)
+                .bikeCreator(bikeCreator)
+                // TODO: Add combat vehicle creator
+                .build();
+
+        vehicleCreatorService.save(vehicleCreator).block();
     }
 
     public void loadPlaybooks() {

--- a/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/MockCharacterLoader.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/MockCharacterLoader.java
@@ -214,8 +214,8 @@ public class MockCharacterLoader implements CommandLineRunner {
                 .armor(1)
                 .handling(0)
                 .strengths(List.of("fast"))
-                .weaknesses(List.of("quirky", "vintage"))
-                .looks(List.of("loud"))
+                .looks(List.of("quirky", "vintage"))
+                .weaknesses(List.of("loud"))
                 .build();
 
         Vehicle car2 = Vehicle.builder()
@@ -250,8 +250,8 @@ public class MockCharacterLoader implements CommandLineRunner {
                 .armor(0)
                 .handling(0)
                 .strengths(List.of("tight", "huge"))
-                .weaknesses(List.of("massively-chopped", "fat-ass"))
-                .looks(List.of("bucking", "unreliable"))
+                .looks(List.of("massively-chopped", "fat-ass"))
+                .weaknesses(List.of("bucking", "unreliable"))
                 .build();
 
         // -------------------------------- Create Sara's Angel ----------------------------------- //

--- a/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/MockCharacterLoader.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/MockCharacterLoader.java
@@ -2,18 +2,12 @@ package com.mersiades.awcweb.bootstrap;
 
 import com.mersiades.awccontent.enums.*;
 import com.mersiades.awccontent.models.*;
-import com.mersiades.awccontent.models.uniquecreators.BikeCreator;
-import com.mersiades.awccontent.models.uniquecreators.CarCreator;
-import com.mersiades.awccontent.services.LookService;
-import com.mersiades.awccontent.services.MoveService;
-import com.mersiades.awccontent.services.StatsOptionService;
-import com.mersiades.awccontent.services.PlaybookCreatorService;
+import com.mersiades.awccontent.services.*;
 import com.mersiades.awcdata.models.Character;
 import com.mersiades.awcdata.models.*;
 import com.mersiades.awcdata.models.uniques.AngelKit;
 import com.mersiades.awcdata.models.uniques.BrainerGear;
 import com.mersiades.awcdata.models.uniques.CustomWeapons;
-import com.mersiades.awcdata.models.uniques.Vehicle;
 import com.mersiades.awcdata.repositories.CharacterRepository;
 import com.mersiades.awcdata.services.CharacterService;
 import com.mersiades.awcdata.services.GameRoleService;
@@ -46,6 +40,7 @@ public class MockCharacterLoader implements CommandLineRunner {
     private final StatsOptionService statsOptionService;
     private final MoveService moveService;
     private final PlaybookCreatorService playbookCreatorService;
+    private final VehicleCreatorService vehicleCreatorService;
 
     @Autowired
     CharacterRepository characterRepository;
@@ -54,13 +49,16 @@ public class MockCharacterLoader implements CommandLineRunner {
                                LookService lookService,
                                CharacterService characterService,
                                StatsOptionService statsOptionService,
-                               MoveService moveService, PlaybookCreatorService playbookCreatorService) {
+                               MoveService moveService,
+                               PlaybookCreatorService playbookCreatorService,
+                               VehicleCreatorService vehicleCreatorService) {
         this.gameRoleService = gameRoleService;
         this.lookService = lookService;
         this.characterService = characterService;
         this.statsOptionService = statsOptionService;
         this.moveService = moveService;
         this.playbookCreatorService = playbookCreatorService;
+        this.vehicleCreatorService = vehicleCreatorService;
     }
 
     @Override
@@ -197,17 +195,20 @@ public class MockCharacterLoader implements CommandLineRunner {
 
         PlaybookCreator driverCreator = playbookCreatorService.findByPlaybookType(PlaybookType.DRIVER).block();
         assert driverCreator != null;
-        CarCreator carCreator = driverCreator.getPlaybookUniqueCreator().getCarCreator();
-        BikeCreator bikeCreator = driverCreator.getPlaybookUniqueCreator().getBikeCreator();
+        VehicleCreator vehicleCreator = vehicleCreatorService.findAll().take(1).blockFirst();
+        assert vehicleCreator != null;
 
 
         Vehicle car1 = Vehicle.builder()
                 .id(UUID.randomUUID().toString())
+                .vehicleType(VehicleType.CAR)
                 .name("Unnamed vehicle")
                 // SMALL frame
-                .vehicleFrame(carCreator.getFrames().get(1))
+                .vehicleFrame(vehicleCreator.getCarCreator().getFrames().get(1))
                 // +1speed, +1armor
-                .battleOptions(List.of(carCreator.getBattleOptions().get(0), carCreator.getBattleOptions().get(3)))
+                .battleOptions(List.of(
+                        vehicleCreator.getCarCreator().getBattleOptions().get(0),
+                        vehicleCreator.getCarCreator().getBattleOptions().get(3)))
                 .massive(1)
                 .speed(1)
                 .armor(1)
@@ -219,11 +220,14 @@ public class MockCharacterLoader implements CommandLineRunner {
 
         Vehicle car2 = Vehicle.builder()
                 .id(UUID.randomUUID().toString())
+                .vehicleType(VehicleType.CAR)
                 .name("Bess")
                 // LARGE frame
-                .vehicleFrame(carCreator.getFrames().get(3))
+                .vehicleFrame(vehicleCreator.getCarCreator().getFrames().get(3))
                 // +1massive, +1armor
-                .battleOptions(List.of(carCreator.getBattleOptions().get(2), carCreator.getBattleOptions().get(3)))
+                .battleOptions(List.of(
+                        vehicleCreator.getCarCreator().getBattleOptions().get(2),
+                        vehicleCreator.getCarCreator().getBattleOptions().get(3)))
                 .massive(4)
                 .speed(0)
                 .armor(1)
@@ -235,11 +239,12 @@ public class MockCharacterLoader implements CommandLineRunner {
 
         Vehicle bike = Vehicle.builder()
                 .id(UUID.randomUUID().toString())
+                .vehicleType(VehicleType.BIKE)
                 .name("Ducati Monster")
                 // BIKE frame
-                .vehicleFrame(bikeCreator.getFrame())
+                .vehicleFrame(vehicleCreator.getBikeCreator().getFrame())
                 // +1speed
-                .battleOptions(List.of(bikeCreator.getBattleOptions().get(0)))
+                .battleOptions(List.of(vehicleCreator.getBikeCreator().getBattleOptions().get(0)))
                 .massive(0)
                 .speed(1)
                 .armor(0)
@@ -247,11 +252,6 @@ public class MockCharacterLoader implements CommandLineRunner {
                 .strengths(List.of("tight", "huge"))
                 .weaknesses(List.of("massively-chopped", "fat-ass"))
                 .looks(List.of("bucking", "unreliable"))
-                .build();
-
-        PlaybookUnique driverPlaybookUnique = PlaybookUnique.builder()
-                .id(UUID.randomUUID().toString())
-                .vehicles(List.of(car1, car2, bike))
                 .build();
 
         // -------------------------------- Create Sara's Angel ----------------------------------- //
@@ -301,10 +301,10 @@ public class MockCharacterLoader implements CommandLineRunner {
                 .gear(List.of("Leather jacket", ".38 revolver"))
                 .statsBlock(driverStatsBlock)
                 .barter(4)
-                .playbookUnique(driverPlaybookUnique)
                 .characterMoves(characterMoves4)
                 .hasCompletedCharacterCreation(true)
                 .vehicleCount(3)
+                .vehicles(List.of(car1, car2, bike))
                 .build();
 
         // ----------------------- Add Characters to players and save ----------------------------- //

--- a/awc-web/src/main/java/com/mersiades/awcweb/graphql/Mutation.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/graphql/Mutation.java
@@ -4,7 +4,7 @@ import com.mersiades.awcdata.models.Character;
 import com.mersiades.awcdata.models.CharacterHarm;
 import com.mersiades.awcdata.models.Game;
 import com.mersiades.awcdata.models.HxStat;
-import com.mersiades.awcdata.models.uniques.Vehicle;
+import com.mersiades.awcdata.models.Vehicle;
 import com.mersiades.awcdata.services.GameRoleService;
 import com.mersiades.awcdata.services.GameService;
 import com.mersiades.awccontent.enums.LookType;

--- a/awc-web/src/main/java/com/mersiades/awcweb/graphql/Query.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/graphql/Query.java
@@ -1,20 +1,22 @@
 package com.mersiades.awcweb.graphql;
 
+import com.mersiades.awccontent.enums.PlaybookType;
+import com.mersiades.awccontent.models.Move;
+import com.mersiades.awccontent.models.Playbook;
+import com.mersiades.awccontent.models.PlaybookCreator;
+import com.mersiades.awccontent.models.VehicleCreator;
+import com.mersiades.awccontent.services.MoveService;
+import com.mersiades.awccontent.services.PlaybookCreatorService;
+import com.mersiades.awccontent.services.PlaybookService;
+import com.mersiades.awccontent.services.VehicleCreatorService;
 import com.mersiades.awcdata.models.Game;
 import com.mersiades.awcdata.models.GameRole;
 import com.mersiades.awcdata.services.GameRoleService;
 import com.mersiades.awcdata.services.GameService;
 import com.mersiades.awcdata.services.UserService;
-import com.mersiades.awccontent.enums.PlaybookType;
 import graphql.kickstart.tools.GraphQLQueryResolver;
-import com.mersiades.awccontent.models.Move;
-import com.mersiades.awccontent.models.Playbook;
-import com.mersiades.awccontent.models.PlaybookCreator;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import com.mersiades.awccontent.services.MoveService;
-import com.mersiades.awccontent.services.PlaybookCreatorService;
-import com.mersiades.awccontent.services.PlaybookService;
 
 import java.util.List;
 
@@ -27,14 +29,22 @@ public class Query implements GraphQLQueryResolver {
     private final MoveService moveService;
     private final PlaybookService playbookService;
     private final PlaybookCreatorService playbookCreatorService;
+    private final VehicleCreatorService vehicleCreatorService;
 
-    public Query(UserService userService, GameRoleService gameRoleService, GameService gameService, MoveService moveService, PlaybookService playbookService, PlaybookCreatorService playbookCreatorService) {
+    public Query(UserService userService,
+                 GameRoleService gameRoleService,
+                 GameService gameService,
+                 MoveService moveService,
+                 PlaybookService playbookService,
+                 PlaybookCreatorService playbookCreatorService,
+                 VehicleCreatorService vehicleCreatorService) {
         this.userService = userService;
         this.gameRoleService = gameRoleService;
         this.gameService = gameService;
         this.moveService = moveService;
         this.playbookService = playbookService;
         this.playbookCreatorService = playbookCreatorService;
+        this.vehicleCreatorService = vehicleCreatorService;
     }
 
     @CrossOrigin
@@ -92,5 +102,9 @@ public class Query implements GraphQLQueryResolver {
 
     public PlaybookCreator playbookCreator(PlaybookType playbookType) {
         return playbookCreatorService.findByPlaybookType(playbookType).block();
+    }
+
+    public VehicleCreator vehicleCreator() {
+        return vehicleCreatorService.findAll().take(1).blockFirst();
     }
 }

--- a/awc-web/src/main/resources/schema.graphqls
+++ b/awc-web/src/main/resources/schema.graphqls
@@ -89,7 +89,6 @@ enum UniqueType {
     CUSTOM_WEAPONS,
     BRAINER_GEAR,
     GANG,
-    VEHICLE,
     WEAPONS,
     HOLDING,
     FOLLOWERS,
@@ -110,6 +109,12 @@ enum BattleOptionType {
     HANDLING,
     MASSIVE,
     ARMOR
+}
+
+enum VehicleType {
+    BIKE,
+    CAR,
+    COMBAT
 }
 
 # ---------------------------------------- STATIC GAME DATA TYPES -------------------------------------- #
@@ -222,6 +227,7 @@ type PlaybookCreator {
     defaultMoves: [Move]
     defaultMoveCount: Int
     moveChoiceCount: Int
+    defaultVehicleCount: Int
 }
 
 type PlaybookUniqueCreator {
@@ -230,8 +236,6 @@ type PlaybookUniqueCreator {
     angelKitCreator: AngelKitCreator
     customWeaponsCreator: CustomWeaponsCreator
     brainerGearCreator: BrainerGearCreator
-    carCreator: CarCreator
-    bikeCreator: BikeCreator
 }
 
 type AngelKitCreator {
@@ -261,6 +265,7 @@ type BrainerGearCreator {
 
 type CarCreator {
     id: ID!
+    vehicleType: VehicleType
     introInstructions: String
     frames: [VehicleFrame]
     strengths: [String]
@@ -271,12 +276,19 @@ type CarCreator {
 
 type BikeCreator {
     id: ID!
+    vehicleType: VehicleType
     introInstructions: String
     frame: VehicleFrame
     strengths: [String]
     looks: [String]
     weaknesses: [String]
     battleOptions: [VehicleBattleOption]
+}
+
+type VehicleCreator {
+    id: ID!
+    bikeCreator: BikeCreator
+    carCreator: CarCreator
 }
 
 # ---------------------------------------- GAME & CHARACTER TYPES --------------------------------------- #
@@ -381,6 +393,7 @@ type Character {
     barter: Int
     harm: CharacterHarm
     vehicleCount: Int
+    vehicles: [Vehicle]
 }
 
 type GameRole {
@@ -436,6 +449,7 @@ type CustomWeapons {
 
 type Vehicle {
     id: ID!
+    vehicleType: VehicleType
     name: String
     vehicleFrame: VehicleFrame
     speed: Int

--- a/awc-web/src/main/resources/schema.graphqls
+++ b/awc-web/src/main/resources/schema.graphqls
@@ -521,6 +521,7 @@ input VehicleBattleOptionInput {
 }
 input VehicleInput {
     id: ID
+    vehicleType: VehicleType
     name: String
     vehicleFrame: VehicleFrameInput
     speed: Int
@@ -544,6 +545,7 @@ type Query {
     playbooks: [Playbook]
     playbook(playbookType: PlaybookType!): Playbook
     playbookCreator(playbookType: PlaybookType!): PlaybookCreator
+    vehicleCreator: VehicleCreator
 }
 
 # --------------------------------------------- MUTATIONS -------------------------------------------- #


### PR DESCRIPTION
This PR adds a VehicleCreator model and moves the `vehicles` fields from within PlaybookUnique up a level to Character.

The CarCreator and BikeCreator used to live within PlaybookUniqueCreator. Now, VehicleCreator acts as a container for CarCreator and BikeCreator. It's been completely separated form the PlaybookUnique system. This is because:

  - Chopper has both a PlaybookUnique and a Vehicle
  - To allow, in the future, all characters to add Vehicles.