### PR TITLE
Adding maven release plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@ A web interface to play Apocalypse World online
 
 ### Deploying the app 
 
+- Checkout the `master` branch
+- run `./mvnw clean release:prepare` 
+  - this get the maven-release-plugin to update the release versions, commit the changes, and push commits to Github
+- run `./mvnw release:clean` to remove all the temporary files `release:perform` generates
 - run `mvn clean package`
-- manually deploy to AWS Elastic Beanstalk environment
+- manually deploy JAR to AWS Elastic Beanstalk environment
 
+
+
+- if you change your mind after running `./mvnw clean release:perform`, you can run `./mvnw release:rollback`.
+  - You may need to manually delete the release tag from Github
+    
 ### Testing the app
 
 - run `mvn clean install`

--- a/awc-content/pom.xml
+++ b/awc-content/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>awcentral</artifactId>
         <groupId>com.mersiades</groupId>
-        <version>${revision}</version>
+        <version>0.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/awc-content/pom.xml
+++ b/awc-content/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>awcentral</artifactId>
         <groupId>com.mersiades</groupId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/awc-data/pom.xml
+++ b/awc-data/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.mersiades</groupId>
 		<artifactId>awcentral</artifactId>
-		<version>${revision}</version>
+		<version>0.0.1</version>
 	</parent>
 	<artifactId>awc-data</artifactId>
 	<name>awc-data</name>

--- a/awc-data/pom.xml
+++ b/awc-data/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.mersiades</groupId>
 		<artifactId>awcentral</artifactId>
-		<version>0.0.1</version>
+		<version>0.0.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>awc-data</artifactId>
 	<name>awc-data</name>

--- a/awc-web/pom.xml
+++ b/awc-web/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.mersiades</groupId>
         <artifactId>awcentral</artifactId>
-        <version>${revision}</version>
+        <version>0.0.1</version>
     </parent>
     <artifactId>awc-web</artifactId>
     <name>awc-web</name>

--- a/awc-web/pom.xml
+++ b/awc-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.mersiades</groupId>
         <artifactId>awcentral</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.2-SNAPSHOT</version>
     </parent>
     <artifactId>awc-web</artifactId>
     <name>awc-web</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.3.1.RELEASE</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
     <groupId>com.mersiades</groupId>
     <artifactId>awcentral</artifactId>
-    <version>${revision}</version>
+    <version>0.0.1</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -76,7 +74,8 @@
     <scm>
         <developerConnection>scm:git:https://github.com/mersiades/awcentral.git</developerConnection>
         <url>https://github.com/mersiades/awcentral</url>
-    </scm>
+      <tag>awcentral-0.0.1</tag>
+  </scm>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.mersiades</groupId>
     <artifactId>awcentral</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -74,7 +74,7 @@
     <scm>
         <developerConnection>scm:git:https://github.com/mersiades/awcentral.git</developerConnection>
         <url>https://github.com/mersiades/awcentral</url>
-      <tag>awcentral-0.0.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <graphql-starter.version>7.1.0</graphql-starter.version>
         <graphiql-starter.version>5.0.2</graphiql-starter.version>
         <graphql-tools.version>6.2.0</graphql-tools.version>
+        <project.scm.id>github</project.scm.id>
     </properties>
 
     <dependencies>
@@ -72,6 +73,11 @@
         </dependencies>
     </dependencyManagement>
 
+    <scm>
+        <developerConnection>scm:git:https://github.com/mersiades/awcentral.git</developerConnection>
+        <url>https://github.com/mersiades/awcentral</url>
+    </scm>
+
     <build>
         <plugins>
             <plugin>
@@ -96,6 +102,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This PR adds the maven-release-plugin.

It has only been partially set up: the `release:perform` command doesn't work.

`release:prepare`, however, can be run during deploy process to update the app version numbers.