### PR TITLE
Adding unit tests for awc content

### DIFF
--- a/awc-content/src/main/java/com/mersiades/awccontent/models/Look.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/Look.java
@@ -25,16 +25,4 @@ public class Look {
 
     private PlaybookCreator playbookCreator;
 
-    public Look(PlaybookType playbookType, LookType category, String look) {
-        this.playbookType = playbookType;
-        this.category = category;
-        this.look = look;
-    }
-
-    public Look(String id, PlaybookType playbookType, LookType category, String look) {
-        this.id = id;
-        this.playbookType = playbookType;
-        this.category = category;
-        this.look = look;
-    }
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/Move.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/Move.java
@@ -33,12 +33,4 @@ public class Move  {
     private PlaybookType playbook;
 
     private MoveAction moveAction;
-
-    public Move(String name, String description, StatType stat, MoveType kind, PlaybookType playbook) {
-        this.name = name;
-        this.description = description;
-        this.stat = stat;
-        this.kind = kind;
-        this.playbook = playbook;
-    }
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/Name.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/Name.java
@@ -24,8 +24,4 @@ public class Name {
     // Many to one
     private PlaybookCreator playbookCreator;
 
-    public Name(PlaybookType playbookType, String name) {
-        this.playbookType = playbookType;
-        this.name = name;
-    }
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/Playbook.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/Playbook.java
@@ -34,12 +34,4 @@ public class Playbook  {
 
     // one to one
     private PlaybookCreator creator;
-
-    public Playbook(PlaybookType playbookType, String barterInstructions, String intro, String introComment, String playbookImageUrl) {
-        this.playbookType = playbookType;
-        this.barterInstructions = barterInstructions;
-        this.intro = intro;
-        this.introComment = introComment;
-        this.playbookImageUrl = playbookImageUrl;
-    }
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/PlaybookCreator.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/PlaybookCreator.java
@@ -51,12 +51,4 @@ public class PlaybookCreator {
 
     @Builder.Default
     private List<StatsOption> statsOptions = new ArrayList<>();
-
-    public PlaybookCreator(PlaybookType playbookType, GearInstructions gearInstructions, String improvementInstructions, String movesInstructions, String hxInstructions) {
-        this.playbookType = playbookType;
-        this.gearInstructions = gearInstructions;
-        this.improvementInstructions = improvementInstructions;
-        this.movesInstructions = movesInstructions;
-        this.hxInstructions = hxInstructions;
-    }
 }

--- a/awc-content/src/main/java/com/mersiades/awccontent/models/StatsOption.java
+++ b/awc-content/src/main/java/com/mersiades/awccontent/models/StatsOption.java
@@ -28,15 +28,5 @@ public class StatsOption {
 
     private int WEIRD;
 
-    // many to one
     private PlaybookCreator playbookCreator;
-
-    public StatsOption(PlaybookType playbookType, int COOL, int HARD, int HOT, int SHARP, int WEIRD) {
-        this.playbookType = playbookType;
-        this.COOL = COOL;
-        this.HARD = HARD;
-        this.HOT = HOT;
-        this.SHARP = SHARP;
-        this.WEIRD = WEIRD;
-    }
 }

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/LookRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/LookRepositoryTest.java
@@ -4,7 +4,6 @@ import com.mersiades.awccontent.enums.LookType;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.Look;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,6 @@ import reactor.test.StepVerifier;
 
 
 //@DataMongoTest
-@Disabled
 @ExtendWith(SpringExtension.class)
 @SpringBootApplication
 public class LookRepositoryTest {

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/LookRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/LookRepositoryTest.java
@@ -23,11 +23,31 @@ public class LookRepositoryTest {
 
     @BeforeEach
     public void setup() {
-        Look angel1 = new Look(PlaybookType.ANGEL, LookType.GENDER, "man");
-        Look angel2 = new Look(PlaybookType.ANGEL, LookType.CLOTHES, "utility wear");
-        Look angel3 = new Look(PlaybookType.ANGEL, LookType.FACE, "kind face");
-        Look angel4 = new Look(PlaybookType.ANGEL, LookType.EYES, "quick eyes");
-        Look angel5 = new Look(PlaybookType.ANGEL, LookType.BODY, "compact body");
+        Look angel1 = Look.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .category(LookType.GENDER)
+                .look("man").build();
+
+        Look angel2 = Look.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .category(LookType.CLOTHES)
+                .look("utility wear").build();
+
+        Look angel3 = Look.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .category(LookType.FACE)
+                .look("kind face").build();
+
+        Look angel4 = Look.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .category(LookType.EYES)
+                .look("quick eyes").build();
+
+        Look angel5 = Look.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .category(LookType.BODY)
+                .look("compact body").build();
+
         lookRepository.deleteAll()
                 .thenMany(Flux.just(angel1, angel2, angel3, angel4, angel5))
                 .flatMap(lookRepository::save)

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/MoveRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/MoveRepositoryTest.java
@@ -24,7 +24,7 @@ public class MoveRepositoryTest {
         Move iceCold = Move.builder().name("ICE COLD").description("_**Ice cold**_: when ...").kind(MoveType.CHARACTER).playbook(PlaybookType.BATTLEBABE).build();
         Move merciless = Move.builder().name("MERCILESS").description("_**Merciless**_: when ...").kind(MoveType.CHARACTER).playbook(PlaybookType.BATTLEBABE).build();
         Move profCompassion = Move.builder().name("PROFESSIONAL COMPASSION").description("_**Professional compassion**_: you can ...").kind(MoveType.CHARACTER).playbook(PlaybookType.ANGEL).build();
-        Move battlefieldGrace = new Move("BATTLEFIELD GRACE", "_**Battlefield grace**_: while you ...", null, MoveType.CHARACTER, PlaybookType.ANGEL);
+        Move battlefieldGrace = Move.builder().name("BATTLEFIELD GRACE").description("_**Battlefield grace**_: while you ...").kind(MoveType.CHARACTER).playbook(PlaybookType.ANGEL).build();
 
         moveRepository.deleteAll()
                 .thenMany(Flux.just(iceCold,merciless, profCompassion, battlefieldGrace))

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/MoveRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/MoveRepositoryTest.java
@@ -4,7 +4,6 @@ import com.mersiades.awccontent.enums.MoveType;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.Move;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,8 +12,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-//@DataMongoTest
-@Disabled
 @ExtendWith({SpringExtension.class})
 @SpringBootApplication
 public class MoveRepositoryTest {
@@ -41,6 +38,14 @@ public class MoveRepositoryTest {
         StepVerifier.create(moveRepository.findAllByPlaybookAndKind(PlaybookType.ANGEL, MoveType.CHARACTER))
                 .expectSubscription()
                 .expectNextCount(2)
+                .verifyComplete();
+    }
+
+    @Test
+    public void shouldFindMoveByMoveName() {
+        StepVerifier.create(moveRepository.findByName("MERCILESS"))
+                .expectSubscription()
+                .expectNextMatches(move -> move.getDescription().equals("_**Merciless**_: when ..."))
                 .verifyComplete();
     }
 

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/NameRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/NameRepositoryTest.java
@@ -20,8 +20,8 @@ public class NameRepositoryTest {
 
     @BeforeEach
     public void setup() {
-        Name dou = new Name(PlaybookType.ANGEL, "Dou");
-        Name bon = new Name(PlaybookType.ANGEL, "Bon");
+        Name dou = Name.builder().playbookType(PlaybookType.ANGEL).name("Dou").build();
+        Name bon = Name.builder().playbookType(PlaybookType.ANGEL).name("Bon").build();
         Name snow = Name.builder().playbookType(PlaybookType.BATTLEBABE).name("Snow").build();
         Name crimson = Name.builder().playbookType(PlaybookType.BATTLEBABE).name("Crimson").build();
         Name smith2 = Name.builder().playbookType(PlaybookType.BRAINER).name("Smith").build();

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/NameRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/NameRepositoryTest.java
@@ -3,7 +3,6 @@ package com.mersiades.awccontent.repositories;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.Name;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-//@DataMongoTest
-@Disabled
 @ExtendWith({SpringExtension.class})
 @SpringBootApplication
 public class NameRepositoryTest {

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/PlaybookCreatorRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/PlaybookCreatorRepositoryTest.java
@@ -3,7 +3,6 @@ package com.mersiades.awccontent.repositories;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.PlaybookCreator;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-//@DataMongoTest
-@Disabled
 @ExtendWith({SpringExtension.class})
 @SpringBootApplication
 class PlaybookCreatorRepositoryTest {

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/PlaybookRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/PlaybookRepositoryTest.java
@@ -20,15 +20,19 @@ public class PlaybookRepositoryTest {
 
     @BeforeEach
     public void setup() {
-        Playbook angel = new Playbook(PlaybookType.ANGEL, "At the beginning ....",
-                "When you’re lying ...",
-                "Angels are medics. ...",
-                "https://awc-images...");
+        Playbook angel = Playbook.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .barterInstructions("At the beginning ....")
+                .intro("When you’re lying ...")
+                .introComment("Angels are medics. ...")
+                .playbookImageUrl("https://awc-images...").build();
 
-        Playbook battlebabe = new Playbook(PlaybookType.BATTLEBABE, "At the beginning ...",
-                "Even in a place ...",
-                "Dangerous...",
-                "https://awc-i...");
+        Playbook battlebabe = Playbook.builder()
+                .playbookType(PlaybookType.BATTLEBABE)
+                .barterInstructions("At the beginning ....")
+                .intro("Even in a place ...")
+                .introComment("Dangerous...")
+                .playbookImageUrl("https://awc-images...").build();
 
         playbookRepository.deleteAll()
                 .thenMany(Flux.just(angel, battlebabe))

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/PlaybookRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/PlaybookRepositoryTest.java
@@ -3,7 +3,6 @@ package com.mersiades.awccontent.repositories;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.Playbook;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-//@DataMongoTest
-@Disabled
 @ExtendWith({SpringExtension.class})
 @SpringBootApplication
 public class PlaybookRepositoryTest {

--- a/awc-content/src/test/java/com/mersiades/awccontent/repositories/StatsOptionRepositoryTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/repositories/StatsOptionRepositoryTest.java
@@ -3,7 +3,6 @@ package com.mersiades.awccontent.repositories;
 import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.StatsOption;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,8 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-//@DataMongoTest
-@Disabled
 @ExtendWith({SpringExtension.class})
 @SpringBootApplication
 public class StatsOptionRepositoryTest {

--- a/awc-content/src/test/java/com/mersiades/awccontent/services/LookServiceImplTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/services/LookServiceImplTest.java
@@ -33,7 +33,12 @@ class LookServiceImplTest {
     void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        mockLook1 = new Look(MOCK_LOOK_ID_1, PlaybookType.BATTLEBABE, LookType.CLOTHES, "Sexy leatherwear");
+        mockLook1 = Look.builder()
+                .id(MOCK_LOOK_ID_1)
+                .category(LookType.CLOTHES)
+                .playbookType(PlaybookType.BATTLEBABE)
+                .look("Sexy leatherwear")
+                .build();
 
         lookService = new LookServiceImpl(lookRepository);
     }
@@ -41,7 +46,11 @@ class LookServiceImplTest {
     @Test
     void shouldFindAllLooks() {
         // Given
-        Look mockLook2 = new Look(PlaybookType.SKINNER, LookType.EYES, "askance");
+        Look mockLook2 = Look.builder()
+                .playbookType(PlaybookType.SKINNER)
+                .category(LookType.EYES)
+                .look("askance").build();
+
         when(lookRepository.findAll()).thenReturn(Flux.just(mockLook1, mockLook2));
 
         // When
@@ -117,7 +126,10 @@ class LookServiceImplTest {
     @Test
     void findAllByPlaybookType() {
         // Given
-        Look mockLook3 = new Look(PlaybookType.BATTLEBABE, LookType.EYES, "almond");
+        Look mockLook3 = Look.builder()
+                .playbookType(PlaybookType.BATTLEBABE)
+                .category(LookType.EYES)
+                .look("almond").build();
         when(lookService.findAllByPlaybookType(any())).thenReturn(Flux.just(mockLook1, mockLook3));
 
         // When

--- a/awc-content/src/test/java/com/mersiades/awccontent/services/MoveServiceImplTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/services/MoveServiceImplTest.java
@@ -1,7 +1,10 @@
 package com.mersiades.awccontent.services;
 
 import com.mersiades.awccontent.enums.MoveType;
+import com.mersiades.awccontent.enums.PlaybookType;
 import com.mersiades.awccontent.models.Move;
+import com.mersiades.awccontent.repositories.MoveRepository;
+import com.mersiades.awccontent.services.impl.MoveServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -9,8 +12,6 @@ import org.mockito.MockitoAnnotations;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import com.mersiades.awccontent.repositories.MoveRepository;
-import com.mersiades.awccontent.services.impl.MoveServiceImpl;
 
 import java.util.List;
 
@@ -117,5 +118,38 @@ class MoveServiceImplTest {
 
         // Then
         verify(moveRepository, times(1)).deleteById(anyString());
+    }
+
+    @Test
+    void shouldFindAllMovesByPlaybookAndKind() {
+        // Given
+        Move iceCold = Move.builder().name("ICE COLD").description("_**Ice cold**_: when ...").kind(MoveType.CHARACTER).playbook(PlaybookType.BATTLEBABE).build();
+        Move merciless = Move.builder().name("MERCILESS").description("_**Merciless**_: when ...").kind(MoveType.CHARACTER).playbook(PlaybookType.BATTLEBABE).build();
+        when(moveRepository.findAllByPlaybookAndKind(PlaybookType.BATTLEBABE, MoveType.CHARACTER)).thenReturn(Flux.just(iceCold, merciless));
+
+        // When
+        List<Move> returnedMoves = moveService.findAllByPlaybookAndKind(PlaybookType.BATTLEBABE, MoveType.CHARACTER).collectList().block();
+
+        // Then
+        assert returnedMoves != null;
+        returnedMoves.forEach(move -> {
+            assertEquals(move.getPlaybook(), PlaybookType.BATTLEBABE);
+            assertEquals(move.getKind(), MoveType.CHARACTER);
+        });
+        verify(moveRepository, times(1)).findAllByPlaybookAndKind(PlaybookType.BATTLEBABE, MoveType.CHARACTER);
+    }
+
+    @Test
+    void shouldFindMoveByName() {
+        // Given
+        when(moveRepository.findByName(anyString())).thenReturn(Mono.just(mockMove1));
+
+        // When
+        Move returnedMove = moveService.findByName(mockMove1.getName()).block();
+
+        // Then
+        assert returnedMove != null;
+        assertEquals(returnedMove.getName(), mockMove1.getName());
+        verify(moveRepository, times(1)).findByName(mockMove1.getName());
     }
 }

--- a/awc-content/src/test/java/com/mersiades/awccontent/services/impl/StatModifierServiceImplTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/services/impl/StatModifierServiceImplTest.java
@@ -1,0 +1,120 @@
+package com.mersiades.awccontent.services.impl;
+
+import com.mersiades.awccontent.enums.StatType;
+import com.mersiades.awccontent.models.StatModifier;
+import com.mersiades.awccontent.repositories.StatModifierRepository;
+import com.mersiades.awccontent.services.StatModifierService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class StatModifierServiceImplTest {
+
+    public static final String MOCK_STAT_MODIFIER_ID_1 = "mock-stat-modifier-id-1";
+
+    @Mock
+    StatModifierRepository statModifierRepository;
+
+    StatModifierService statModifierService;
+
+    StatModifier mockStatModifier1;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        statModifierService = new StatModifierServiceImpl(statModifierRepository);
+
+        mockStatModifier1 = StatModifier.builder()
+                .id(MOCK_STAT_MODIFIER_ID_1)
+                .statToModify(StatType.COOL)
+                .modification(1)
+                .build();
+
+    }
+
+    @Test
+    void shouldFindAllStatModifiers() {
+        // Given
+        StatModifier mockStatModifier2 = StatModifier.builder().build();
+        when(statModifierRepository.findAll()).thenReturn(Flux.just(mockStatModifier1, mockStatModifier2));
+
+        // When
+        List<StatModifier> returnedStatModifiers = statModifierService.findAll().collectList().block();
+
+        // Then
+        assert returnedStatModifiers != null;
+        assertEquals(2, returnedStatModifiers.size());
+        verify(statModifierRepository, times(1)).findAll();
+    }
+
+    @Test
+    void findById() {
+        // Given
+        when(statModifierRepository.findById(anyString())).thenReturn(Mono.just(mockStatModifier1));
+
+        // When
+        StatModifier returnedStatModifier = statModifierService.findById(MOCK_STAT_MODIFIER_ID_1).block();
+
+        // Then
+        assert returnedStatModifier != null;
+        assertEquals(MOCK_STAT_MODIFIER_ID_1, returnedStatModifier.getId());
+        verify(statModifierRepository, times(1)).findById(anyString());
+    }
+
+    @Test
+    void shouldSaveStatModifier() {
+        // Given
+        when(statModifierRepository.save(any(StatModifier.class))).thenReturn(Mono.just(mockStatModifier1));
+
+        // When
+        StatModifier savedStatModifier = statModifierService.save(mockStatModifier1).block();
+
+        // Then
+        assert savedStatModifier != null;
+        assertEquals(MOCK_STAT_MODIFIER_ID_1, savedStatModifier.getId());
+        verify(statModifierRepository, times(1)).save(any(StatModifier.class));
+    }
+
+    @Test
+    void shouldSaveAllStatModifiers() {
+        // Given
+        StatModifier mockStatModifier2 = StatModifier.builder().build();
+        when(statModifierRepository.saveAll(any(Publisher.class))).thenReturn(Flux.just(mockStatModifier1, mockStatModifier2));
+
+        // When
+        List<StatModifier> savedStatModifiers = statModifierService.saveAll(Flux.just(mockStatModifier1, mockStatModifier2)).collectList().block();
+
+        // Then
+        assert savedStatModifiers != null;
+        assertEquals(2, savedStatModifiers.size());
+        verify(statModifierRepository, times(1)).saveAll(any(Publisher.class));
+    }
+
+    @Test
+    void shouldDeleteStatModifier() {
+        // When
+        statModifierService.delete(mockStatModifier1);
+
+        // Then
+        verify(statModifierRepository, times(1)).delete(any(StatModifier.class));
+    }
+
+    @Test
+    void deleteById() {
+        // When
+        statModifierService.deleteById(MOCK_STAT_MODIFIER_ID_1);
+
+        // Then
+        verify(statModifierRepository, times(1)).deleteById(anyString());
+    }
+}

--- a/awc-content/src/test/java/com/mersiades/awccontent/services/impl/ThreatCreatorServiceImplTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/services/impl/ThreatCreatorServiceImplTest.java
@@ -1,0 +1,121 @@
+package com.mersiades.awccontent.services.impl;
+
+import com.mersiades.awccontent.models.ThreatCreator;
+import com.mersiades.awccontent.repositories.ThreatCreatorRepository;
+import com.mersiades.awccontent.services.ThreatCreatorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ThreatCreatorServiceImplTest {
+
+    public static final String MOCK_THREAT_CREATOR_ID_1 = "mock-threat-creator-id-1";
+
+    @Mock
+    ThreatCreatorRepository threatCreatorRepository;
+
+    ThreatCreatorService threatCreatorService;
+
+    ThreatCreator mockThreatCreator1;
+
+    ThreatCreator mockThreatCreator2;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        threatCreatorService = new ThreatCreatorServiceImpl(threatCreatorRepository);
+
+        mockThreatCreator1 =  ThreatCreator.builder()
+                .id(MOCK_THREAT_CREATOR_ID_1)
+                .threatNames(List.of("Tum Tum", "Gnarly", "Fleece"))
+                .createThreatInstructions("To create a threat:")
+                .essentialThreatInstructions("Where the PCs are, create as landscape")
+                .build();
+
+        mockThreatCreator2 = ThreatCreator.builder().build();
+    }
+
+    @Test
+    void shouldFindAllThreatCreators() {
+        // Given
+        when(threatCreatorRepository.findAll()).thenReturn(Flux.just(mockThreatCreator1, mockThreatCreator2));
+
+        // When
+        List<ThreatCreator> returnedThreatCreators = threatCreatorService.findAll().collectList().block();
+
+        // Then
+        assert returnedThreatCreators != null;
+        assertEquals(2, returnedThreatCreators.size());
+        verify(threatCreatorRepository, times(1)).findAll();
+    }
+
+    @Test
+    void shouldFindThreatCreatorById() {
+        // Given
+        when(threatCreatorRepository.findById(anyString())).thenReturn(Mono.just(mockThreatCreator1));
+
+        // When
+        ThreatCreator returnedThreatCreator = threatCreatorService.findById(MOCK_THREAT_CREATOR_ID_1).block();
+
+        // Then
+        assert returnedThreatCreator != null;
+        assertEquals(MOCK_THREAT_CREATOR_ID_1, returnedThreatCreator.getId());
+        verify(threatCreatorRepository, times(1)).findById(anyString());
+    }
+
+    @Test
+    void shouldSaveThreatCreator() {
+        // Given
+        when(threatCreatorService.save(any(ThreatCreator.class))).thenReturn(Mono.just(mockThreatCreator1));
+
+        // When
+        ThreatCreator savedThreatCreator = threatCreatorService.save(mockThreatCreator1).block();
+
+        // Then
+        assert savedThreatCreator != null;
+        assertEquals(MOCK_THREAT_CREATOR_ID_1, savedThreatCreator.getId());
+        verify(threatCreatorRepository, times(1)).save(any(ThreatCreator.class));
+    }
+
+    @Test
+    void shouldSaveAllThreatCreators() {
+        // Given
+        when(threatCreatorRepository.saveAll(any(Publisher.class))).thenReturn(Flux.just(mockThreatCreator1, mockThreatCreator2));
+
+        // When
+        List<ThreatCreator> savedThreatCreators = threatCreatorService.saveAll(Flux.just(mockThreatCreator1, mockThreatCreator2)).collectList().block();
+
+        // Then
+        assert savedThreatCreators != null;
+        assertEquals(2, savedThreatCreators.size());
+        verify(threatCreatorRepository, times(1)).saveAll(any(Publisher.class));
+    }
+
+    @Test
+    void shouldDeleteThreatCreator() {
+        // When
+        threatCreatorService.delete(mockThreatCreator1);
+
+        // Then
+        verify(threatCreatorRepository, times(1)).delete(any(ThreatCreator.class));
+    }
+
+    @Test
+    void shouldDeleteThreatCreatorById() {
+        // When
+        threatCreatorService.deleteById(MOCK_THREAT_CREATOR_ID_1);
+
+        // Then
+        verify(threatCreatorRepository, times(1)).deleteById(anyString());
+    }
+}

--- a/awc-content/src/test/java/com/mersiades/awccontent/services/impl/VehicleCreatorServiceImplTest.java
+++ b/awc-content/src/test/java/com/mersiades/awccontent/services/impl/VehicleCreatorServiceImplTest.java
@@ -1,0 +1,117 @@
+package com.mersiades.awccontent.services.impl;
+
+import com.mersiades.awccontent.models.VehicleCreator;
+import com.mersiades.awccontent.repositories.VehicleCreatorRepository;
+import com.mersiades.awccontent.services.VehicleCreatorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class VehicleCreatorServiceImplTest {
+
+    public static final String MOCK_VEHICLE_CREATOR_ID_1 = "mock-vehicle-creator-id-1";
+
+    @Mock
+    VehicleCreatorRepository vehicleCreatorRepository;
+
+    VehicleCreatorService vehicleCreatorService;
+
+    VehicleCreator mockVehicleCreator1;
+
+    VehicleCreator mockVehicleCreator2;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        vehicleCreatorService = new VehicleCreatorServiceImpl(vehicleCreatorRepository);
+
+        mockVehicleCreator1 = VehicleCreator.builder()
+                .id(MOCK_VEHICLE_CREATOR_ID_1).build();
+
+        mockVehicleCreator2 = VehicleCreator.builder().build();
+    }
+
+    @Test
+    void shouldFindAllVehicleCreators() {
+        // Given
+        when(vehicleCreatorRepository.findAll()).thenReturn(Flux.just(mockVehicleCreator1, mockVehicleCreator2));
+
+        // When
+        List<VehicleCreator> returnedVehicleCreators = vehicleCreatorService.findAll().collectList().block();
+
+        // Then
+        assert returnedVehicleCreators != null;
+        assertEquals(2, returnedVehicleCreators.size());
+        verify(vehicleCreatorRepository, times(1)).findAll();
+    }
+
+    @Test
+    void shouldFindVehicleCreatorById() {
+        // Given
+        when(vehicleCreatorRepository.findById(anyString())).thenReturn(Mono.just(mockVehicleCreator1));
+
+        // When
+        VehicleCreator returnedVehicleCreator = vehicleCreatorService.findById(MOCK_VEHICLE_CREATOR_ID_1).block();
+
+        // Then
+        assert returnedVehicleCreator != null;
+        assertEquals(MOCK_VEHICLE_CREATOR_ID_1, returnedVehicleCreator.getId());
+        verify(vehicleCreatorRepository, times(1)).findById(anyString());
+    }
+
+    @Test
+    void shouldSaveVehicleCreator() {
+        // Given
+        when(vehicleCreatorService.save(any(VehicleCreator.class))).thenReturn(Mono.just(mockVehicleCreator1));
+
+        // When
+        VehicleCreator savedVehicleCreator = vehicleCreatorService.save(mockVehicleCreator1).block();
+
+        // Then
+        assert savedVehicleCreator != null;
+        assertEquals(MOCK_VEHICLE_CREATOR_ID_1, savedVehicleCreator.getId());
+        verify(vehicleCreatorRepository, times(1)).save(any(VehicleCreator.class));
+    }
+
+    @Test
+    void shouldSaveAllVehicleCreators() {
+        // Given
+        when(vehicleCreatorRepository.saveAll(any(Publisher.class))).thenReturn(Flux.just(mockVehicleCreator1, mockVehicleCreator2));
+
+        // When
+        List<VehicleCreator> savedVehicleCreators = vehicleCreatorService.saveAll(Flux.just(mockVehicleCreator1, mockVehicleCreator2)).collectList().block();
+
+        // Then
+        assert savedVehicleCreators != null;
+        assertEquals(2, savedVehicleCreators.size());
+        verify(vehicleCreatorRepository, times(1)).saveAll(any(Publisher.class));
+    }
+
+    @Test
+    void shouldDeleteVehicleCreator() {
+        // When
+        vehicleCreatorService.delete(mockVehicleCreator1);
+
+        // Then
+        verify(vehicleCreatorRepository, times(1)).delete(any(VehicleCreator.class));
+    }
+
+    @Test
+    void shouldDeleteVehicleCreatorById() {
+        // When
+        vehicleCreatorService.deleteById(MOCK_VEHICLE_CREATOR_ID_1);
+
+        // Then
+        verify(vehicleCreatorRepository, times(1)).deleteById(anyString());
+    }
+}

--- a/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
@@ -4390,219 +4390,295 @@ public class GameDataLoader implements CommandLineRunner {
     public void loadPlaybooks() {
         System.out.println("|| --- Loading playbooks --- ||");
         /* ----------------------------- ANGEL PLAYBOOK --------------------------------- */
-        Playbook angel = new Playbook(PlaybookType.ANGEL, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Tend to the health of a dozen families or more*\n" +
-                "- *Serve a wealthy NPC as angel on call*\n" +
-                "- *Serve a warlord NPC as combat medic*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "When you’re lying in the dust of Apocalypse World guts aspilled, for whom do you pray? The gods? They’re long gone. Your beloved comrades? Fuckers all, or you wouldn’t be here to begin with. Your precious old mother? She’s a darling but she can’t put an intestine back inside so it’ll stay. No, you pray for some grinning kid or veteran or just someone with a heartshocker and a hand with sutures and a 6-pack of morphine. And when that someone comes, _that’s_ an angel.", "Angels are medics. If you want everybody to love you, or at least rely on you, play an angel. Warning: if things are going well, maybe nobody will rely on you. Make interesting relationships so you’ll stay relevant. Or sabotage things, I guess.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/angel-white-transparent.png");
 
-        Playbook battlebabe = new Playbook(PlaybookType.BATTLEBABE, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Extort, raid, or rob a wealthy population*\n" +
-                "- *Execute a murder on behalf of a wealthy NPC*\n" +
-                "- *Serve a wealthy NPC as a bodyguard*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Even in a place as dangerous as Apocalypse World, battlebabes are, well. They’re the ones you should walk away from, eyes down, but you can’t. They’re the ones like the seductive blue crackling light, y’know? You mistake looking at them for falling in love, and you get too close and it’s a zillion volts and your wings burn off like paper.", "Dangerous.\n" +
-                "\n" +
-                "Battlebabes are good in battle, of course, but they’re wicked social too. If you want to play somebody dangerous and provocative, play a battlebabe. Warning: you might find that you’re better at making trouble than getting out of it. If you want to play the baddest ass, play a gunlugger instead.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/battlebabe-white-transparent.png");
-        Playbook brainer = new Playbook(PlaybookType.BRAINER, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Interrogate a warlord NPC’s prisoners*\n" +
-                "- *Extort or blackmail a wealthy NPC*\n" +
-                "- *Serve a wealthy NPC as kept brainer*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Brainers are the weird psycho psychic mindfucks of Apocalypse World. They have brain control, puppet strings, creepy hearts, dead souls, and eyes like broken things. They stand in your peripheral vision and whisper into your head, staring. They clamp lenses over your eyes and read your secrets.\n" +
-                "\n" +
-                "They’re just the sort of tasteful accoutrement that no well-appointed hardhold can do without.", "Brainers are spooky, weird, and really fun to play. Their moves are powerful but strange. If you want everybody else to be at least a little bit afraid of you, a brainer is a good choice. Warning: you’ll be happy anyway, but you’ll be happiest if somebody wants to have sex with you even though you’re a brainer. Angle for that if you can.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/brainer-white-transparent.png");
-        Playbook chopper = new Playbook(PlaybookType.CHOPPER, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Extort, raid, or rob a wealthy population*\n" +
-                "- *Execute a murder on behalf of a wealthy NPC*\n" +
-                "- *Serve a wealthy NPC as a bodyguard*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Apocalypse World is all scarcity, of course it is. There’s not enough wholesome food, not enough untainted water, not enough security, not enough light, not enough electricity, not enough children, not enough hope.\n" +
-                "\n" +
-                "However, the Golden Age Past did leave us two things: enough gasoline, enough bullets. Come the end, I guess the fuckers didn’t need them like they thought they would.\n" +
-                "\n" +
-                "So chopper, there you are. Enough for you.", "Choppers lead biker gangs. They’re powerful but lots of their power is external, in their gang. If you want weight to throw around, play a chopper—but if you want to be really in charge, play a hardholder instead. Warning: externalizing your power means drama. Expect drama.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/chopper-white-transparent.png");
-        Playbook driver = new Playbook(PlaybookType.DRIVER, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Serve a wealthy NPC as driver*\n" +
-                "- *Serve a wealthy NPC as courier*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Came the apocalypse, and the infrastructure of the Golden Age tore apart. Roads heaved and split. Lines of life and communication shattered. Cities, cut off from one another, raged like smashed anthills, then burned, then fell.\n" +
-                "\n" +
-                "A few living still remember it: every horizon scorching hot with civilization in flames, light to put out the stars and moon, smoke to put out the sun.\n" +
-                "\n" +
-                "In Apocalypse World the horizons are dark, and no roads go to them.", "Drivers have cars, meaning mobility, freedom, and places to go. If you can’t see the post-apocalypse without cars, you gotta be a driver. Warning: your loose ties can accidentally keep you out of the action. Commit to the other characters to stay in play.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/driver-white-transparent.png");
-        Playbook gunlugger = new Playbook(PlaybookType.GUNLUGGER, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Extort, raid, or rob a wealthy population*\n" +
-                "- *Execute a murder on behalf of a wealthy NPC*\n" +
-                "- *Serve a wealthy NPC as a bodyguard*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Apocalypse World is a mean, ugly, violent place. Law and society have broken down completely. What’s yours is yours only while you can hold it in your hands. There’s no peace. There’s no stability but what you carve, inch by inch, out of the concrete and dirt, and then defend with murder and blood.\n" +
-                "\n" +
-                "Sometimes the obvious move is the right one.", "Gunluggers are the baddest asses. Their moves are simple, direct and violent. Crude, even. If you want to take no shit, play a gunlugger. Warning: like angels, if things are going well, you might be kicking your heels. Interesting relationships can keep you in the scene.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/gunlugger-white-transparent.png");
-        Playbook hardholder = new Playbook(PlaybookType.HARDHOLDER, "Your holding provides for your day-to-day living, so while you’re there governing it, you need not spend barter for your lifestyle at the beginning of the session.\n" +
-                "\n" +
-                "When you give gifts, here’s what might count as a gift worth 1-barter:\n" +
-                "\n" +
-                "- *a month’s hospitality, including a place to live and meals in common with others*\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear by your fave savvyhead or techso*\n" +
-                "- *a week’s bestowal of the protective companionship of one of your battlebabes, gunluggers, or gang members*\n" +
-                "- *a month’s maintenance and repairs for a hi-performance vehicle well-used; a half-hour’s worth of your undivided attention, in private audience*\n" +
-                "- *or, of course, oddments worth 1-barter*\n" +
-                "  \n" +
-                "In times of abundance, your holding’s surplus is yours to spend personally as you see fit. (Suppose that your citizen’s lives are the more abundant too, in proportion.) You can see what 1-barter is worth, from the above. For better stuff, be prepared to make unique arrangements, probably by treating with another hardholder nearby.", "There is no government, no society, in Apocalypse World. When hardholders ruled whole continents, when they waged war on the other side of the world instead of with the hold across the burn-flat, when their armies numbered in the hundreds of thousands and they had fucking _boats_ to hold their fucking _airplanes_ on, that was the golden age of legend. Now, anyone with a concrete compound and a gang of gunluggers can claim the title. You, you got something to say about it?", "Hardholders are landlords, warlords, governors of their own little strongholds. If anybody plays a hardholder, the game’s going to have a serious and immobile home base. If you want to be the one who owns it, it better be you. Warning: don’t be a hardholder unless you want the burdens.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/hardholder-white-transparent.png");
-        Playbook hocus = new Playbook(PlaybookType.HOCUS, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Serve a wealthy NPC as auger and advisor*\n" +
-                "- *Serve a population as counselor and ceremonist*\n" +
-                "- *Serve a wealthy NPC as ceremonist*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Now it should be crystal fucking obvious that the gods have abandoned Apocalypse World. Maybe in the golden age, with its one nation under god and its in god we trust, maybe then the gods were real. Fucked if I know. All I know is that now they’re gone daddy gone.\n" +
-                "\n" +
-                "My theory is that these weird hocus fuckers, when they say “the gods,” what they really mean is the miasma left over from the explosion of psychic hate and desperation that gave Apocalypse World its birth. Friends, that’s our creator now.", "Hocuses have cult followers the way choppers have gangs. They’re strange, social, public and compelling. If you want to sway mobs, play a hocus. Warning: things are going to come looking for you. Being a cult leader means having to deal with your fucking cult.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/hocus-white-transparent.png");
-        Playbook maestroD = new Playbook(PlaybookType.MAESTRO_D, "Your establishment provides for your day-to-day living, so while you’re open for business, you need not spend barter for your lifestyle at the beginning of the session.\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *the material costs for crash resuscitation by a medic*\n" +
-                "- *a few sessions’ tribute to a warlord; bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "In the golden age of legend, there was this guy named Maestro. He was known for dressing up real dap and wherever he went, the people had much luxe tune. There was this other guy named Maitre d’. He was known for dressing up real dap and whever he went, the people had all the food they could eat and the fanciest of it.\n" +
-                "\n" +
-                "Here in Apocalypse World, those two guys are dead. They died and the fat sizzled off them, they died same as much-luxe-tune and all-you-can-eat. The maestro d’ now, he can’t give you what those guys used to could, but fuck it, maybe he can find you a little somethin somethin to take off the edge.", "The maestro d’ runs a social establishment, like a bar, a drug den or a bordello. If you want to be sexier than a hardholder, with fewer obligations and less shit to deal with, play a maestro d’. Warning: fewer obligations and less shit, not none and none.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/maestrod-white-transparent.png");
-        Playbook savvyhead = new Playbook(PlaybookType.SAVVYHEAD, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Maintain a wealthy NPC’s �nicky or fragile tech*\n" +
-                "- *Repair a wealthy NPC’s hi-tech equipment*\n" +
-                "- *Conduct research for a wealthy NPC*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "If there’s one fucking thing you can count on in Apocalypse World, it’s: things break.", "Savvyheads are techies. They have really cool abilities in the form of their workspace, and a couple of fun reality-bending moves. Play a savvyhead if you want to be powerful and useful as an ally, but maybe not the leader yourself. Warning: your workspace depends on resources, and lots of them, so make friends with everyone you can.", "https://awc-images.s3-ap-southeast-2.amazonaws.com/savvyhead-white-transparent.png");
-        Playbook skinner = new Playbook(PlaybookType.SKINNER, "At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
-                "\n" +
-                "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
-                "\n" +
-                "- *Perform for a public audience*\n" +
-                "- *Appear at the side of a wealthy NPC*\n" +
-                "- *Perform for a private audience*\n" +
-                "- *Others, as you negotiate them*\n" +
-                "\n" +
-                "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
-                "\n" +
-                "- *a night in high luxury & company*\n" +
-                "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
-                "- *repair of a piece of hi-tech gear*\n" +
-                "- *a session’s hire of a violent individual as bodyguard*\n" +
-                "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
-                "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
-                "\n" +
-                "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.", "Even in the filth of Apocalypse World, there’s food that isn’t death on a spit, music that isn’t shrieking hyenas, thoughts that aren’t afraid, bodies that aren’t used meat, sex that isn’t rutting, dancing that’s real. There are moments that are more than stench, smoke, rage and blood.\n" +
-                "\n" +
-                "Anything beautiful left in this ugly ass world, skinners hold it. Will they share it with you? What do you offer _them_?", "Skinners are pure hot. They’re entirely social and they have great, directly manipulative moves. Play a skinner if you want to be unignorable. Warning: skinners have the tools, but unlike hardholders, choppers and hocuses, they don’t have a steady influx of motivation. You’ll have most fun if you can roll your own.\n", "https://awc-images.s3-ap-southeast-2.amazonaws.com/skinner-white-transparent.png");
+        Playbook angel = Playbook.builder()
+                .playbookType(PlaybookType.ANGEL)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Tend to the health of a dozen families or more*\n" +
+                        "- *Serve a wealthy NPC as angel on call*\n" +
+                        "- *Serve a warlord NPC as combat medic*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("When you’re lying in the dust of Apocalypse World guts aspilled, for whom do you pray? The gods? They’re long gone. Your beloved comrades? Fuckers all, or you wouldn’t be here to begin with. Your precious old mother? She’s a darling but she can’t put an intestine back inside so it’ll stay. No, you pray for some grinning kid or veteran or just someone with a heartshocker and a hand with sutures and a 6-pack of morphine. And when that someone comes, _that’s_ an angel.")
+                .introComment("Angels are medics. If you want everybody to love you, or at least rely on you, play an angel. Warning: if things are going well, maybe nobody will rely on you. Make interesting relationships so you’ll stay relevant. Or sabotage things, I guess.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/angel-white-transparent.png")
+                .build();
+
+        Playbook battlebabe = Playbook.builder()
+                .playbookType(PlaybookType.BATTLEBABE)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Extort, raid, or rob a wealthy population*\n" +
+                        "- *Execute a murder on behalf of a wealthy NPC*\n" +
+                        "- *Serve a wealthy NPC as a bodyguard*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Even in a place as dangerous as Apocalypse World, battlebabes are, well. They’re the ones you should walk away from, eyes down, but you can’t. They’re the ones like the seductive blue crackling light, y’know? You mistake looking at them for falling in love, and you get too close and it’s a zillion volts and your wings burn off like paper.")
+                .introComment("Dangerous.\n" +
+                        "\n" +
+                        "Battlebabes are good in battle, of course, but they’re wicked social too. If you want to play somebody dangerous and provocative, play a battlebabe. Warning: you might find that you’re better at making trouble than getting out of it. If you want to play the baddest ass, play a gunlugger instead.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/battlebabe-white-transparent.png")
+                .build();
+
+        Playbook brainer = Playbook.builder()
+                .playbookType(PlaybookType.BRAINER)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Interrogate a warlord NPC’s prisoners*\n" +
+                        "- *Extort or blackmail a wealthy NPC*\n" +
+                        "- *Serve a wealthy NPC as kept brainer*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Brainers are the weird psycho psychic mindfucks of Apocalypse World. They have brain control, puppet strings, creepy hearts, dead souls, and eyes like broken things. They stand in your peripheral vision and whisper into your head, staring. They clamp lenses over your eyes and read your secrets.\n" +
+                        "\n" +
+                        "They’re just the sort of tasteful accoutrement that no well-appointed hardhold can do without.")
+                .introComment("Brainers are spooky, weird, and really fun to play. Their moves are powerful but strange. If you want everybody else to be at least a little bit afraid of you, a brainer is a good choice. Warning: you’ll be happy anyway, but you’ll be happiest if somebody wants to have sex with you even though you’re a brainer. Angle for that if you can.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/brainer-white-transparent.png")
+                .build();
+
+        Playbook chopper = Playbook.builder()
+                .playbookType(PlaybookType.CHOPPER)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Extort, raid, or rob a wealthy population*\n" +
+                        "- *Execute a murder on behalf of a wealthy NPC*\n" +
+                        "- *Serve a wealthy NPC as a bodyguard*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Apocalypse World is all scarcity, of course it is. There’s not enough wholesome food, not enough untainted water, not enough security, not enough light, not enough electricity, not enough children, not enough hope.\n" +
+                        "\n" +
+                        "However, the Golden Age Past did leave us two things: enough gasoline, enough bullets. Come the end, I guess the fuckers didn’t need them like they thought they would.\n" +
+                        "\n" +
+                        "So chopper, there you are. Enough for you.")
+                .introComment("Choppers lead biker gangs. They’re powerful but lots of their power is external, in their gang. If you want weight to throw around, play a chopper—but if you want to be really in charge, play a hardholder instead. Warning: externalizing your power means drama. Expect drama.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/chopper-white-transparent.png")
+                .build();
+
+        Playbook driver = Playbook.builder()
+                .playbookType(PlaybookType.DRIVER)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Serve a wealthy NPC as driver*\n" +
+                        "- *Serve a wealthy NPC as courier*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Came the apocalypse, and the infrastructure of the Golden Age tore apart. Roads heaved and split. Lines of life and communication shattered. Cities, cut off from one another, raged like smashed anthills, then burned, then fell.\n" +
+                        "\n" +
+                        "A few living still remember it: every horizon scorching hot with civilization in flames, light to put out the stars and moon, smoke to put out the sun.\n" +
+                        "\n" +
+                        "In Apocalypse World the horizons are dark, and no roads go to them.")
+                .introComment("Drivers have cars, meaning mobility, freedom, and places to go. If you can’t see the post-apocalypse without cars, you gotta be a driver. Warning: your loose ties can accidentally keep you out of the action. Commit to the other characters to stay in play.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/driver-white-transparent.png")
+                .build();
+
+        Playbook gunlugger = Playbook.builder()
+                .playbookType(PlaybookType.GUNLUGGER)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Extort, raid, or rob a wealthy population*\n" +
+                        "- *Execute a murder on behalf of a wealthy NPC*\n" +
+                        "- *Serve a wealthy NPC as a bodyguard*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Apocalypse World is a mean, ugly, violent place. Law and society have broken down completely. What’s yours is yours only while you can hold it in your hands. There’s no peace. There’s no stability but what you carve, inch by inch, out of the concrete and dirt, and then defend with murder and blood.\n" +
+                        "\n" +
+                        "Sometimes the obvious move is the right one.")
+                .introComment("Gunluggers are the baddest asses. Their moves are simple, direct and violent. Crude, even. If you want to take no shit, play a gunlugger. Warning: like angels, if things are going well, you might be kicking your heels. Interesting relationships can keep you in the scene.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/gunlugger-white-transparent.png")
+                .build();
+
+        Playbook hardholder = Playbook.builder()
+                .playbookType(PlaybookType.HARDHOLDER)
+                .barterInstructions("Your holding provides for your day-to-day living, so while you’re there governing it, you need not spend barter for your lifestyle at the beginning of the session.\n" +
+                        "\n" +
+                        "When you give gifts, here’s what might count as a gift worth 1-barter:\n" +
+                        "\n" +
+                        "- *a month’s hospitality, including a place to live and meals in common with others*\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear by your fave savvyhead or techso*\n" +
+                        "- *a week’s bestowal of the protective companionship of one of your battlebabes, gunluggers, or gang members*\n" +
+                        "- *a month’s maintenance and repairs for a hi-performance vehicle well-used; a half-hour’s worth of your undivided attention, in private audience*\n" +
+                        "- *or, of course, oddments worth 1-barter*\n" +
+                        "  \n" +
+                        "In times of abundance, your holding’s surplus is yours to spend personally as you see fit. (Suppose that your citizen’s lives are the more abundant too, in proportion.) You can see what 1-barter is worth, from the above. For better stuff, be prepared to make unique arrangements, probably by treating with another hardholder nearby.")
+                .intro("There is no government, no society, in Apocalypse World. When hardholders ruled whole continents, when they waged war on the other side of the world instead of with the hold across the burn-flat, when their armies numbered in the hundreds of thousands and they had fucking _boats_ to hold their fucking _airplanes_ on, that was the golden age of legend. Now, anyone with a concrete compound and a gang of gunluggers can claim the title. You, you got something to say about it?")
+                .introComment("Hardholders are landlords, warlords, governors of their own little strongholds. If anybody plays a hardholder, the game’s going to have a serious and immobile home base. If you want to be the one who owns it, it better be you. Warning: don’t be a hardholder unless you want the burdens.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/hardholder-white-transparent.png")
+                .build();
+
+        Playbook hocus = Playbook.builder()
+                .playbookType(PlaybookType.HOCUS)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Serve a wealthy NPC as auger and advisor*\n" +
+                        "- *Serve a population as counselor and ceremonist*\n" +
+                        "- *Serve a wealthy NPC as ceremonist*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Now it should be crystal fucking obvious that the gods have abandoned Apocalypse World. Maybe in the golden age, with its one nation under god and its in god we trust, maybe then the gods were real. Fucked if I know. All I know is that now they’re gone daddy gone.\n" +
+                        "\n" +
+                        "My theory is that these weird hocus fuckers, when they say “the gods,” what they really mean is the miasma left over from the explosion of psychic hate and desperation that gave Apocalypse World its birth. Friends, that’s our creator now.")
+                .introComment("Hocuses have cult followers the way choppers have gangs. They’re strange, social, public and compelling. If you want to sway mobs, play a hocus. Warning: things are going to come looking for you. Being a cult leader means having to deal with your fucking cult.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/hocus-white-transparent.png")
+                .build();
+
+        Playbook maestroD = Playbook.builder()
+                .playbookType(PlaybookType.MAESTRO_D)
+                .barterInstructions("Your establishment provides for your day-to-day living, so while you’re open for business, you need not spend barter for your lifestyle at the beginning of the session.\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *the material costs for crash resuscitation by a medic*\n" +
+                        "- *a few sessions’ tribute to a warlord; bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("In the golden age of legend, there was this guy named Maestro. He was known for dressing up real dap and wherever he went, the people had much luxe tune. There was this other guy named Maitre d’. He was known for dressing up real dap and wherever he went, the people had all the food they could eat and the fanciest of it.\n" +
+                        "\n" +
+                        "Here in Apocalypse World, those two guys are dead. They died and the fat sizzled off them, they died same as much-luxe-tune and all-you-can-eat. The maestro d’ now, he can’t give you what those guys used to could, but fuck it, maybe he can find you a little somethin somethin to take off the edge.")
+                .introComment("The maestro d’ runs a social establishment, like a bar, a drug den or a bordello. If you want to be sexier than a hardholder, with fewer obligations and less shit to deal with, play a maestro d’. Warning: fewer obligations and less shit, not none and none.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/maestrod-white-transparent.png")
+                .build();
+
+        Playbook savvyhead = Playbook.builder()
+                .playbookType(PlaybookType.SAVVYHEAD)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Maintain a wealthy NPC’s �nicky or fragile tech*\n" +
+                        "- *Repair a wealthy NPC’s hi-tech equipment*\n" +
+                        "- *Conduct research for a wealthy NPC*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("If there’s one fucking thing you can count on in Apocalypse World, it’s: things break.")
+                .introComment("Savvyheads are techies. They have really cool abilities in the form of their workspace, and a couple of fun reality-bending moves. Play a savvyhead if you want to be powerful and useful as an ally, but maybe not the leader yourself. Warning: your workspace depends on resources, and lots of them, so make friends with everyone you can.")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/savvyhead-white-transparent.png")
+                .build();
+
+        Playbook skinner = Playbook.builder()
+                .playbookType(PlaybookType.SKINNER)
+                .barterInstructions("At the beginning of the session, spend 1- or 2-barter for your lifestyle. If you can’t or won’t, tell the MC and answer her questions.\n" +
+                        "\n" +
+                        "If you need jingle during a session, tell the MC you’d like to work a gig. Your gigs:\n" +
+                        "\n" +
+                        "- *Perform for a public audience*\n" +
+                        "- *Appear at the side of a wealthy NPC*\n" +
+                        "- *Perform for a private audience*\n" +
+                        "- *Others, as you negotiate them*\n" +
+                        "\n" +
+                        "As a one-time expenditure, and very subject to availability, 1-barter might count for:\n" +
+                        "\n" +
+                        "- *a night in high luxury & company*\n" +
+                        "- *any weapon, gear or fashion not valuable or hi-tech*\n" +
+                        "- *repair of a piece of hi-tech gear*\n" +
+                        "- *a session’s hire of a violent individual as bodyguard*\n" +
+                        "- *a few sessions’ tribute to a warlord; a few sessions’ maintenance and repairs for a hi-performance vehicle well-used*\n" +
+                        "- *bribes, fees and gifts sufficient to get you into almost anyone’s presence*\n" +
+                        "\n" +
+                        "For better stuff, you should expect to make particular arrangements. You can’t just wander around the commons of some hardhold with oddments ajangle and expect to find hi-tech or luxe eternal.")
+                .intro("Even in the filth of Apocalypse World, there’s food that isn’t death on a spit, music that isn’t shrieking hyenas, thoughts that aren’t afraid, bodies that aren’t used meat, sex that isn’t rutting, dancing that’s real. There are moments that are more than stench, smoke, rage and blood.\n" +
+                        "\n" +
+                        "Anything beautiful left in this ugly ass world, skinners hold it. Will they share it with you? What do you offer _them_?")
+                .introComment("Skinners are pure hot. They’re entirely social and they have great, directly manipulative moves. Play a skinner if you want to be unignorable. Warning: skinners have the tools, but unlike hardholders, choppers and hocuses, they don’t have a steady influx of motivation. You’ll have most fun if you can roll your own.\n")
+                .playbookImageUrl("https://awc-images.s3-ap-southeast-2.amazonaws.com/skinner-white-transparent.png")
+                .build();
 
         playbookService.saveAll(Flux.just(angel, battlebabe, brainer, chopper, driver, gunlugger, hardholder,
                 maestroD, hocus, savvyhead, skinner)).blockLast();

--- a/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
@@ -2396,42 +2396,42 @@ public class GameDataLoader implements CommandLineRunner {
     private void loadLooks() {
         System.out.println("|| --- Loading playbook looks --- ||");
         /* ----------------------------- ANGEL LOOKS --------------------------------- */
-        Look angel1 = new Look(PlaybookType.ANGEL, LookType.GENDER, "man");
-        Look angel2 = new Look(PlaybookType.ANGEL, LookType.GENDER, "woman");
-        Look angel3 = new Look(PlaybookType.ANGEL, LookType.GENDER, "ambiguous");
-        Look angel4 = new Look(PlaybookType.ANGEL, LookType.GENDER, "transgressing");
-        Look angel5 = new Look(PlaybookType.ANGEL, LookType.GENDER, "concealed");
-        Look angel6 = new Look(PlaybookType.ANGEL, LookType.CLOTHES, "utility wear");
-        Look angel7 = new Look(PlaybookType.ANGEL, LookType.CLOTHES, "casual wear plus utility");
-        Look angel8 = new Look(PlaybookType.ANGEL, LookType.CLOTHES, "scrounge wear plus utility");
-        Look angel9 = new Look(PlaybookType.ANGEL, LookType.FACE, "kind face");
-        Look angel10 = new Look(PlaybookType.ANGEL, LookType.FACE, "strong face");
-        Look angel11 = new Look(PlaybookType.ANGEL, LookType.FACE, "rugged face");
-        Look angel12 = new Look(PlaybookType.ANGEL, LookType.FACE, "haggard face");
-        Look angel13 = new Look(PlaybookType.ANGEL, LookType.FACE, "pretty face");
-        Look angel14 = new Look(PlaybookType.ANGEL, LookType.FACE, "lively face");
-        Look angel15 = new Look(PlaybookType.ANGEL, LookType.EYES, "quick eyes");
-        Look angel16 = new Look(PlaybookType.ANGEL, LookType.EYES, "hard eyes");
-        Look angel17 = new Look(PlaybookType.ANGEL, LookType.EYES, "caring eyes");
-        Look angel18 = new Look(PlaybookType.ANGEL, LookType.EYES, "bright eyes");
-        Look angel19 = new Look(PlaybookType.ANGEL, LookType.EYES, "laughing eyes");
-        Look angel20 = new Look(PlaybookType.ANGEL, LookType.EYES, "clear eyes");
-        Look angel21 = new Look(PlaybookType.ANGEL, LookType.BODY, "compact body");
-        Look angel22 = new Look(PlaybookType.ANGEL, LookType.BODY, "stout body");
-        Look angel23 = new Look(PlaybookType.ANGEL, LookType.BODY, "spare body");
-        Look angel24 = new Look(PlaybookType.ANGEL, LookType.BODY, "big body");
-        Look angel25 = new Look(PlaybookType.ANGEL, LookType.BODY, "rangy body");
-        Look angel26 = new Look(PlaybookType.ANGEL, LookType.BODY, "sturdy body");
+        Look angel1 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.GENDER).look("man").build();
+        Look angel2 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.GENDER).look("woman").build();
+        Look angel3 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.GENDER).look("ambiguous").build();
+        Look angel4 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.GENDER).look("transgressing").build();
+        Look angel5 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.GENDER).look("concealed").build();
+        Look angel6 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.CLOTHES).look("utility wear").build();
+        Look angel7 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.CLOTHES).look("casual wear plus utility").build();
+        Look angel8 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.CLOTHES).look("scrounge wear plus utility").build();
+        Look angel9 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.FACE).look("kind face").build();
+        Look angel10 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.FACE).look("strong face").build();
+        Look angel11 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.FACE).look("rugged face").build();
+        Look angel12 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.FACE).look("haggard face").build();
+        Look angel13 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.FACE).look("pretty face").build();
+        Look angel14 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.FACE).look("lively face").build();
+        Look angel15 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.EYES).look("quick eyes").build();
+        Look angel16 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.EYES).look("hard eyes").build();
+        Look angel17 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.EYES).look("caring eyes").build();
+        Look angel18 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.EYES).look("bright eyes").build();
+        Look angel19 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.EYES).look("laughing eyes").build();
+        Look angel20 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.EYES).look("clear eyes").build();
+        Look angel21 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.BODY).look("compact body").build();
+        Look angel22 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.BODY).look("stout body").build();
+        Look angel23 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.BODY).look("spare body").build();
+        Look angel24 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.BODY).look("big body").build();
+        Look angel25 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.BODY).look("rangy body").build();
+        Look angel26 = Look.builder().playbookType(PlaybookType.ANGEL).category(LookType.BODY).look("sturdy body").build();
 
         lookService.saveAll(Flux.just(angel1, angel2, angel3, angel4, angel5, angel6, angel7, angel8, angel9,
                 angel10, angel11, angel12, angel13, angel14, angel15, angel16, angel17, angel18, angel19,
                 angel20, angel21, angel22, angel23, angel24, angel25, angel26)).blockLast();
 
         /* ----------------------------- BATTLEBABE LOOKS --------------------------------- */
-        Look battlebabe1 = new Look(PlaybookType.BATTLEBABE, LookType.GENDER, "man");
-        Look battlebabe2 = new Look(PlaybookType.BATTLEBABE, LookType.GENDER, "woman");
-        Look battlebabe3 = new Look(PlaybookType.BATTLEBABE, LookType.GENDER, "ambiguous");
-        Look battlebabe4 = new Look(PlaybookType.BATTLEBABE, LookType.GENDER, "transgressing");
+        Look battlebabe1 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.GENDER).look("man").build();
+        Look battlebabe2 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.GENDER).look("woman").build();
+        Look battlebabe3 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.GENDER).look("ambiguous").build();
+        Look battlebabe4 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.GENDER).look("transgressing").build();
         Look battlebabe5 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.CLOTHES).look("formal wear").build();
         Look battlebabe6 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.CLOTHES).look("display wear").build();
         Look battlebabe7 = Look.builder().playbookType(PlaybookType.BATTLEBABE).category(LookType.CLOTHES).look("luxe wear").build();
@@ -2461,11 +2461,11 @@ public class GameDataLoader implements CommandLineRunner {
                 battlebabe21, battlebabe22, battlebabe23, battlebabe24, battlebabe25, battlebabe26)).blockLast();
 
         /* ----------------------------- BRAINER LOOKS --------------------------------- */
-        Look brainer1 = new Look(PlaybookType.BRAINER, LookType.GENDER, "man");
-        Look brainer2 = new Look(PlaybookType.BRAINER, LookType.GENDER, "woman");
-        Look brainer3 = new Look(PlaybookType.BRAINER, LookType.GENDER, "ambiguous");
-        Look brainer4 = new Look(PlaybookType.BRAINER, LookType.GENDER, "transgressing");
-        Look brainer5 = new Look(PlaybookType.BRAINER, LookType.GENDER, "concealed");
+        Look brainer1 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.GENDER).look("man").build();
+        Look brainer2 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.GENDER).look("woman").build();
+        Look brainer3 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.GENDER).look("ambiguous").build();
+        Look brainer4 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.GENDER).look("transgressing").build();
+        Look brainer5 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.GENDER).look("concealed").build();
         Look brainer6 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.CLOTHES).look("high formal wear").build();
         Look brainer7 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.CLOTHES).look("clinical wear").build();
         Look brainer8 = Look.builder().playbookType(PlaybookType.BRAINER).category(LookType.CLOTHES).look("fetish-bondage wear").build();

--- a/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
+++ b/awc-web/src/main/java/com/mersiades/awcweb/bootstrap/GameDataLoader.java
@@ -2049,34 +2049,34 @@ public class GameDataLoader implements CommandLineRunner {
     private void loadNames() {
         System.out.println("|| --- Loading playbook names --- ||");
         /* ----------------------------- ANGEL NAMES --------------------------------- */
-        Name dou = new Name(PlaybookType.ANGEL, "Dou");
-        Name bon = new Name(PlaybookType.ANGEL, "Bon");
-        Name abe = new Name(PlaybookType.ANGEL, "Abe");
-        Name boo = new Name(PlaybookType.ANGEL, "Boo");
-        Name t = new Name(PlaybookType.ANGEL, "T");
-        Name kal = new Name(PlaybookType.ANGEL, "Kal");
-        Name charName = new Name(PlaybookType.ANGEL, "Char");
-        Name jav = new Name(PlaybookType.ANGEL, "Jav");
-        Name ruth = new Name(PlaybookType.ANGEL, "Ruth");
-        Name wei = new Name(PlaybookType.ANGEL, "Wei");
-        Name jay = new Name(PlaybookType.ANGEL, "Jay");
-        Name nee = new Name(PlaybookType.ANGEL, "Nee");
-        Name kim = new Name(PlaybookType.ANGEL, "Kim");
-        Name lan = new Name(PlaybookType.ANGEL, "Lan");
-        Name di = new Name(PlaybookType.ANGEL, "Di");
-        Name dez = new Name(PlaybookType.ANGEL, "Dez");
-        Name doc = new Name(PlaybookType.ANGEL, "Doc");
-        Name core = new Name(PlaybookType.ANGEL, "Core");
-        Name wheels = new Name(PlaybookType.ANGEL, "Wheels");
-        Name buzz = new Name(PlaybookType.ANGEL, "Buzz");
-        Name key = new Name(PlaybookType.ANGEL, "Key");
-        Name line = new Name(PlaybookType.ANGEL, "Line");
-        Name gabe = new Name(PlaybookType.ANGEL, "Gabe");
-        Name biz = new Name(PlaybookType.ANGEL, "Biz");
-        Name bish = new Name(PlaybookType.ANGEL, "Bish");
-        Name inch = new Name(PlaybookType.ANGEL, "Inch");
-        Name grip = new Name(PlaybookType.ANGEL, "Grip");
-        Name setter = new Name(PlaybookType.ANGEL, "Setter");
+        Name dou = Name.builder().playbookType(PlaybookType.ANGEL).name("Dou").build();
+        Name bon = Name.builder().playbookType(PlaybookType.ANGEL).name("Bon").build();
+        Name abe = Name.builder().playbookType(PlaybookType.ANGEL).name("Abe").build();
+        Name boo = Name.builder().playbookType(PlaybookType.ANGEL).name("Boo").build();
+        Name t = Name.builder().playbookType(PlaybookType.ANGEL).name("T").build();
+        Name kal = Name.builder().playbookType(PlaybookType.ANGEL).name("Kal").build();
+        Name charName = Name.builder().playbookType(PlaybookType.ANGEL).name("Char").build();
+        Name jav = Name.builder().playbookType(PlaybookType.ANGEL).name("Jav").build();
+        Name ruth = Name.builder().playbookType(PlaybookType.ANGEL).name("Ruth").build();
+        Name wei = Name.builder().playbookType(PlaybookType.ANGEL).name("Wei").build();
+        Name jay = Name.builder().playbookType(PlaybookType.ANGEL).name("Jay").build();
+        Name nee = Name.builder().playbookType(PlaybookType.ANGEL).name("Nee").build();
+        Name kim = Name.builder().playbookType(PlaybookType.ANGEL).name("Kim").build();
+        Name lan = Name.builder().playbookType(PlaybookType.ANGEL).name("Lan").build();
+        Name di = Name.builder().playbookType(PlaybookType.ANGEL).name("Di").build();
+        Name dez = Name.builder().playbookType(PlaybookType.ANGEL).name("Dez").build();
+        Name doc = Name.builder().playbookType(PlaybookType.ANGEL).name("Doc").build();
+        Name core = Name.builder().playbookType(PlaybookType.ANGEL).name("Core").build();
+        Name wheels = Name.builder().playbookType(PlaybookType.ANGEL).name("Wheels").build();
+        Name buzz = Name.builder().playbookType(PlaybookType.ANGEL).name("Buzz").build();
+        Name key = Name.builder().playbookType(PlaybookType.ANGEL).name("Key").build();
+        Name line = Name.builder().playbookType(PlaybookType.ANGEL).name("Line").build();
+        Name gabe = Name.builder().playbookType(PlaybookType.ANGEL).name("Gabe").build();
+        Name biz = Name.builder().playbookType(PlaybookType.ANGEL).name("Biz").build();
+        Name bish = Name.builder().playbookType(PlaybookType.ANGEL).name("Bish").build();
+        Name inch = Name.builder().playbookType(PlaybookType.ANGEL).name("Inch").build();
+        Name grip = Name.builder().playbookType(PlaybookType.ANGEL).name("Grip").build();
+        Name setter = Name.builder().playbookType(PlaybookType.ANGEL).name("Setter").build();
 
         nameService.saveAll(Flux.just(dou, bon, abe, boo, t, kal, charName, jav, ruth, wei, jay, nee,
                 kim, lan, di, dez, core, wheels, doc, buzz, key, line, gabe, biz, bish, inch, grip, setter))


### PR DESCRIPTION
This PR adds a few more unit tests to the awc-content module, so that repositories and services are at 100% coverage.

It also finally removes all old constructors in favour of builder patterns.